### PR TITLE
feat(domains): add custom click tracking support

### DIFF
--- a/examples/domains.rb
+++ b/examples/domains.rb
@@ -19,6 +19,22 @@ def create
   puts "deleted #{domain[:id]}"
 end
 
+def create_with_tracking
+  params = {
+    name: "example@example.com",
+    region: "us-east-1",
+    tracking_subdomain: "links",
+  }
+  domain = Resend::Domains.create(params)
+  puts "open_tracking: #{domain[:open_tracking]}"
+  puts "click_tracking: #{domain[:click_tracking]}"
+  puts "tracking_subdomain: #{domain[:tracking_subdomain]}"
+  puts domain
+
+  Resend::Domains.remove domain[:id]
+  puts "deleted #{domain[:id]}"
+end
+
 def get
   domain = Resend::Domains.create({name: "test"})
   puts "created domain id: #{domain[:id]}"
@@ -39,7 +55,8 @@ def update
     id: domain[:id],
     open_tracking: false,
     click_tracking: false,
-    tls: "enforced"
+    tls: "enforced",
+    tracking_subdomain: "links",
   }
   updated = Resend::Domains.update(params)
   puts "updated domain: #{updated[:id]}"
@@ -75,6 +92,7 @@ def verify
 end
 
 create
+create_with_tracking
 get
 update
 list

--- a/spec/domains_spec.rb
+++ b/spec/domains_spec.rb
@@ -71,6 +71,65 @@ RSpec.describe "Domains" do
       expect(Resend::Domains.create(params)[:id]).to eql("4dd369bc-aa82-4ff3-97de-514ae3000ee0")
     end
 
+    it "should create domain record with tracking_subdomain" do
+      resp = {
+        "id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+        "name": "example.com",
+        "createdAt": "2023-03-28T17:12:02.059593+00:00",
+        "status": "not_started",
+        "open_tracking": true,
+        "click_tracking": true,
+        "tracking_subdomain": "links",
+        "records": [
+          {
+            "record": "SPF",
+            "name": "bounces",
+            "type": "MX",
+            "ttl": "Auto",
+            "status": "not_started",
+            "value": "feedback-smtp.us-east-1.amazonses.com",
+            "priority": 10
+          },
+          {
+            "record": "DKIM",
+            "name": "nhapbbryle57yxg3fbjytyodgbt2kyyg._domainkey",
+            "value": "nhapbbryle57yxg3fbjytyodgbt2kyyg.dkim.amazonses.com.",
+            "type": "CNAME",
+            "status": "not_started",
+            "ttl": "Auto"
+          },
+          {
+            "record": "Tracking",
+            "name": "links.example.com",
+            "value": "links1.resend-dns.com",
+            "type": "CNAME",
+            "ttl": "Auto",
+            "status": "not_started"
+          }
+        ],
+        "region": "us-east-1",
+        "dnsProvider": "Unidentified"
+      }
+      params = {
+        "name": "example.com",
+        "region": "us-east-1",
+        "tracking_subdomain": "links"
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      domain = Resend::Domains.create(params)
+      expect(domain[:id]).to eql("4dd369bc-aa82-4ff3-97de-514ae3000ee0")
+      expect(domain[:open_tracking]).to be true
+      expect(domain[:click_tracking]).to be true
+      expect(domain[:tracking_subdomain]).to eql("links")
+      tracking_record = domain[:records].find { |r| r[:record] == "Tracking" }
+      expect(tracking_record).not_to be_nil
+      expect(tracking_record[:name]).to eql("links.example.com")
+      expect(tracking_record[:value]).to eql("links1.resend-dns.com")
+      expect(tracking_record[:type]).to eql("CNAME")
+      expect(tracking_record[:ttl]).to eql("Auto")
+      expect(tracking_record[:status]).to eql("not_started")
+    end
+
     it "should raise when domain is already registered" do
       resp = {
         "name"=>"validation_error",
@@ -112,6 +171,22 @@ RSpec.describe "Domains" do
       expect(domain[:id]).to eql("479e3145-dd38-476b-932c-529ceb705947")
       expect(domain[:object]).to eql("domain")
     end
+
+    it "should update a domain record with tracking_subdomain" do
+      resp = {
+        "object": "domain",
+        "id": "479e3145-dd38-476b-932c-529ceb705947"
+      }
+
+      update_params = {
+        id: '479e3145-dd38-476b-932c-529ceb705947',
+        tracking_subdomain: "links"
+      }
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      domain = Resend::Domains.update(update_params)
+      expect(domain[:id]).to eql("479e3145-dd38-476b-932c-529ceb705947")
+    end
   end
 
   describe "get domain" do
@@ -135,6 +210,28 @@ RSpec.describe "Domains" do
       expect(email[:status]).to eql "not_started"
       expect(email[:created_at]).to eql "2023-04-26T20:21:26.347412+00:00"
       expect(email[:region]).to eql "us-east-1"
+    end
+
+    it "should retrieve domain with tracking fields" do
+      resp = {
+        "object": "domain",
+        "id": "d91cd9bd-1176-453e-8fc1-35364d380206",
+        "name": "example.com",
+        "status": "not_started",
+        "created_at": "2023-04-26T20:21:26.347412+00:00",
+        "region": "us-east-1",
+        "open_tracking": true,
+        "click_tracking": true,
+        "tracking_subdomain": "links"
+      }
+      allow(resp).to receive(:body).and_return(resp)
+      allow(HTTParty).to receive(:send).and_return(resp)
+
+      domain = Resend::Domains.get(resp[:id])
+
+      expect(domain[:open_tracking]).to be true
+      expect(domain[:click_tracking]).to be true
+      expect(domain[:tracking_subdomain]).to eql "links"
     end
   end
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds custom click tracking for domains. You can set a `tracking_subdomain` on create/update and see it in responses and DNS records.

- **New Features**
  - Support `tracking_subdomain` in `Resend::Domains.create` and `.update`.
  - Domain responses include `open_tracking`, `click_tracking`, and `tracking_subdomain`; DNS `records` include the Tracking CNAME when set.
  - Added `create_with_tracking` example and tests for create/get/update.

<sup>Written for commit a30fc38181778e261fa9271e1239a285b1c1982f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

