### PR TITLE
feat(automations,events): add Automations and Events API namespaces

### DIFF
--- a/examples/automations.rb
+++ b/examples/automations.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require_relative "../lib/resend"
+
+raise if ENV["RESEND_API_KEY"].nil?
+
+Resend.api_key = ENV["RESEND_API_KEY"]
+
+# 1. Create a template (needed for the send_email step config)
+template = Resend::Templates.create({
+  name: "Welcome Email",
+  from: "onboarding@resend.dev",
+  subject: "Welcome!",
+  html: "<p>Welcome to our platform!</p>"
+})
+template_id = template[:id]
+puts "created template: #{template_id}"
+
+Resend::Templates.publish(template_id)
+puts "published template: #{template_id}"
+
+# 2. Create a simple automation: trigger → send_email
+simple_automation = Resend::Automations.create({
+  name: "Simple Welcome Automation",
+  steps: [
+    {
+      key: "trigger",
+      type: "trigger",
+      config: { event_name: "user.created" }
+    },
+    {
+      key: "send_welcome",
+      type: "send_email",
+      config: { template: { id: template_id } }
+    }
+  ],
+  connections: [
+    { from: "trigger", to: "send_welcome", type: "default" }
+  ]
+})
+automation_id = simple_automation[:id]
+puts "created simple automation: #{automation_id}"
+
+# 3. Get automation
+retrieved = Resend::Automations.get(automation_id)
+puts "retrieved automation: #{retrieved[:id]}, status: #{retrieved[:status]}"
+
+# 4. Update automation (change status to enabled)
+updated = Resend::Automations.update({
+  automation_id: automation_id,
+  status: "enabled"
+})
+puts "updated automation: #{updated[:id]}"
+
+# 5. List automations (without filter)
+all_automations = Resend::Automations.list
+puts "automations: #{all_automations[:data].length}, has_more: #{all_automations[:has_more]}"
+
+# List automations with status filter
+enabled_automations = Resend::Automations.list({ status: "enabled" })
+puts "enabled automations: #{enabled_automations[:data].length}"
+
+# 6. Stop automation
+stopped = Resend::Automations.stop(automation_id)
+puts "stopped automation: #{stopped[:id]}"
+
+# 7. List runs (Resend::Automations::Runs.list)
+runs = Resend::Automations::Runs.list(automation_id)
+puts "runs: #{runs[:data].length}, has_more: #{runs[:has_more]}"
+
+# 8. Get a run if any exist (Resend::Automations::Runs.get)
+if runs[:data].any?
+  run_id = runs[:data].first[:id]
+  run = Resend::Automations::Runs.get(automation_id, run_id)
+  puts "run: #{run[:id]}, status: #{run[:status]}"
+else
+  puts "no runs yet for this automation"
+end
+
+# 9. Multi-step automation: trigger → delay → wait_for_event → send_email
+multi_automation = Resend::Automations.create({
+  name: "Multi-step Onboarding Automation",
+  steps: [
+    {
+      key: "trigger",
+      type: "trigger",
+      config: { event_name: "user.created" }
+    },
+    {
+      key: "wait_30_min",
+      type: "delay",
+      config: { duration: "30 minutes" }
+    },
+    {
+      key: "wait_verified",
+      type: "wait_for_event",
+      config: { event_name: "user.verified", timeout: "1 hour" }
+    },
+    {
+      key: "send_welcome",
+      type: "send_email",
+      config: { template: { id: template_id } }
+    }
+  ],
+  connections: [
+    { from: "trigger", to: "wait_30_min", type: "default" },
+    { from: "wait_30_min", to: "wait_verified", type: "default" },
+    { from: "wait_verified", to: "send_welcome", type: "event_received" }
+  ]
+})
+multi_automation_id = multi_automation[:id]
+puts "created multi-step automation: #{multi_automation_id}"
+
+# 10. Cleanup: delete both automations and the template
+Resend::Automations.remove(automation_id)
+puts "removed automation: #{automation_id}"
+
+Resend::Automations.remove(multi_automation_id)
+puts "removed multi-step automation: #{multi_automation_id}"
+
+Resend::Templates.remove(template_id)
+puts "removed template: #{template_id}"

--- a/examples/events.rb
+++ b/examples/events.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require_relative "../lib/resend"
+
+raise if ENV["RESEND_API_KEY"].nil?
+
+Resend.api_key = ENV["RESEND_API_KEY"]
+
+# 1. Create a global contact (needed for event sends)
+contact = Resend::Contacts.create({
+  email: "test.events@example.com",
+  first_name: "Test",
+  last_name: "User"
+})
+contact_id = contact[:id]
+puts "created contact: #{contact_id}"
+
+# 2. Create event without schema
+event_no_schema = Resend::Events.create({ name: "user.signed_up" })
+puts "created event without schema: #{event_no_schema[:id]}"
+
+# 3. Create event with schema
+schema = {
+  "plan" => "string",
+  "trial_days" => "number",
+  "is_enterprise" => "boolean",
+  "upgraded_at" => "date"
+}
+event_with_schema = Resend::Events.create({ name: "user.upgraded", schema: schema })
+event_id = event_with_schema[:id]
+puts "created event with schema: #{event_id}"
+
+# 4. Get event by ID
+fetched_by_id = Resend::Events.get(event_id)
+puts "fetched event by ID: #{fetched_by_id[:id]}, name: #{fetched_by_id[:name]}"
+
+# 5. Get event by name
+fetched_by_name = Resend::Events.get("user.upgraded")
+puts "fetched event by name: #{fetched_by_name[:id]}, name: #{fetched_by_name[:name]}"
+
+# 6. Update event schema
+new_schema = {
+  "plan" => "string",
+  "trial_days" => "number",
+  "is_enterprise" => "boolean",
+  "upgraded_at" => "date",
+  "referral_code" => "string"
+}
+updated_event = Resend::Events.update({ identifier: event_id, schema: new_schema })
+puts "updated event: #{updated_event[:id]}"
+
+# 7. Send event with contact_id
+sent_with_contact_id = Resend::Events.send({
+  event: "user.upgraded",
+  contact_id: contact_id,
+  payload: { plan: "pro", trial_days: 14, is_enterprise: false }
+})
+puts "sent event with contact_id: #{sent_with_contact_id[:event]}"
+
+# 8. Send event with email
+sent_with_email = Resend::Events.send({
+  event: "user.signed_up",
+  email: "test.events@example.com"
+})
+puts "sent event with email: #{sent_with_email[:event]}"
+
+# 9. List events
+events = Resend::Events.list
+puts "total events: #{events[:data].length}, has_more: #{events[:has_more]}"
+
+# 10. List events with pagination params
+paginated = Resend::Events.list({ limit: 5 })
+puts "paginated events (limit 5): #{paginated[:data].length}"
+
+if paginated[:has_more]
+  last_id = paginated[:data].last[:id]
+  more_events = Resend::Events.list({ limit: 5, after: last_id })
+  puts "next page: #{more_events[:data].length}"
+end
+
+# 11. Delete event by ID
+deleted_by_id = Resend::Events.remove(event_id)
+puts "deleted event by ID: #{deleted_by_id[:id]}, deleted: #{deleted_by_id[:deleted]}"
+
+# 12. Delete event by name
+deleted_by_name = Resend::Events.remove("user.signed_up")
+puts "deleted event by name: #{deleted_by_name[:deleted]}"
+
+# 13. Cleanup: delete contact
+Resend::Contacts.remove({ id: contact_id })
+puts "removed contact: #{contact_id}"

--- a/lib/resend.rb
+++ b/lib/resend.rb
@@ -31,6 +31,9 @@ require "resend/emails/receiving/attachments"
 require "resend/logs"
 require "resend/topics"
 require "resend/webhooks"
+require "resend/automations"
+require "resend/automations/runs"
+require "resend/events"
 
 # Rails
 require "resend/railtie" if defined?(Rails) && defined?(ActionMailer)

--- a/lib/resend/automations.rb
+++ b/lib/resend/automations.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Resend
+  # automations api wrapper
+  module Automations
+    class << self
+      # https://resend.com/docs/api-reference/automations/create-automation
+      def create(params = {})
+        Resend::Request.new("automations", params, "post").perform
+      end
+
+      # https://resend.com/docs/api-reference/automations/get-automation
+      def get(automation_id = "")
+        Resend::Request.new("automations/#{automation_id}", {}, "get").perform
+      end
+
+      # https://resend.com/docs/api-reference/automations/update-automation
+      def update(params = {})
+        path = "automations/#{params[:automation_id]}"
+        payload = params.reject { |k, _| k == :automation_id }
+        Resend::Request.new(path, payload, "patch").perform
+      end
+
+      # https://resend.com/docs/api-reference/automations/delete-automation
+      def remove(automation_id = "")
+        Resend::Request.new("automations/#{automation_id}", {}, "delete").perform
+      end
+
+      # https://resend.com/docs/api-reference/automations/stop-automation
+      def stop(automation_id = "")
+        Resend::Request.new("automations/#{automation_id}/stop", {}, "post").perform
+      end
+
+      # https://resend.com/docs/api-reference/automations/list-automations
+      def list(params = {})
+        path = Resend::PaginationHelper.build_paginated_path("automations", params)
+        Resend::Request.new(path, {}, "get").perform
+      end
+    end
+  end
+end

--- a/lib/resend/automations/runs.rb
+++ b/lib/resend/automations/runs.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Resend
+  module Automations
+    # Automation Runs api wrapper
+    module Runs
+      class << self
+        # https://resend.com/docs/api-reference/automations/list-automation-runs
+        def list(automation_id, params = {})
+          base_path = "automations/#{automation_id}/runs"
+          path = Resend::PaginationHelper.build_paginated_path(base_path, params)
+          Resend::Request.new(path, {}, "get").perform
+        end
+
+        # https://resend.com/docs/api-reference/automations/get-automation-run
+        def get(automation_id, run_id)
+          Resend::Request.new("automations/#{automation_id}/runs/#{run_id}", {}, "get").perform
+        end
+      end
+    end
+  end
+end

--- a/lib/resend/events.rb
+++ b/lib/resend/events.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Resend
+  # events api wrapper
+  module Events
+    class << self
+      # https://resend.com/docs/api-reference/events/create-event
+      def create(params = {})
+        Resend::Request.new("events", params, "post").perform
+      end
+
+      # https://resend.com/docs/api-reference/events/get-event
+      # identifier can be a UUID or an event name (e.g. "user.signed_up")
+      def get(identifier = "")
+        path = "events/#{CGI.escape(identifier.to_s)}"
+        Resend::Request.new(path, {}, "get").perform
+      end
+
+      # https://resend.com/docs/api-reference/events/update-event
+      def update(params = {})
+        identifier = params[:identifier]
+        path = "events/#{CGI.escape(identifier.to_s)}"
+        payload = params.reject { |k, _| k == :identifier }
+        Resend::Request.new(path, payload, "patch").perform
+      end
+
+      # https://resend.com/docs/api-reference/events/delete-event
+      # identifier can be a UUID or an event name (e.g. "user.signed_up")
+      def remove(identifier = "")
+        path = "events/#{CGI.escape(identifier.to_s)}"
+        Resend::Request.new(path, {}, "delete").perform
+      end
+
+      # https://resend.com/docs/api-reference/events/send-event
+      def send(params = {})
+        Resend::Request.new("events/send", params, "post").perform
+      end
+
+      # https://resend.com/docs/api-reference/events/list-events
+      def list(params = {})
+        path = Resend::PaginationHelper.build_paginated_path("events", params)
+        Resend::Request.new(path, {}, "get").perform
+      end
+    end
+  end
+end

--- a/spec/automations_spec.rb
+++ b/spec/automations_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+RSpec.describe "Automations" do
+  before do
+    Resend.configure do |config|
+      config.api_key = "re_123"
+    end
+  end
+
+  let(:automation_id) { "auto_abc123" }
+  let(:run_id) { "run_xyz789" }
+
+  let(:steps) do
+    [
+      { key: "trigger", type: "trigger", config: { event_name: "user.created" } },
+      { key: "send_welcome", type: "send_email", config: { template: { id: "tpl_xxx" } } }
+    ]
+  end
+
+  let(:connections) do
+    [{ from: "trigger", to: "send_welcome", type: "default" }]
+  end
+
+  describe "create" do
+    it "should create an automation" do
+      resp = {
+        object: "automation",
+        id: automation_id
+      }
+      params = { name: "Welcome Automation", steps: steps, connections: connections }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Automations.create(params)
+      expect(result[:id]).to eql(automation_id)
+      expect(result[:object]).to eql("automation")
+    end
+
+    it "should use POST /automations" do
+      params = { name: "Welcome Automation", steps: steps, connections: connections }
+      req = double("req", perform: { id: automation_id })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("automations")
+        expect(verb).to eql("post")
+        req
+      end
+      Resend::Automations.create(params)
+    end
+  end
+
+  describe "get" do
+    it "should retrieve an automation" do
+      resp = {
+        object: "automation",
+        id: automation_id,
+        name: "Welcome Automation",
+        status: "enabled",
+        created_at: "2024-01-01T00:00:00.000Z",
+        updated_at: "2024-01-01T00:00:00.000Z",
+        steps: steps,
+        connections: connections
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Automations.get(automation_id)
+      expect(result[:id]).to eql(automation_id)
+      expect(result[:object]).to eql("automation")
+      expect(result[:name]).to eql("Welcome Automation")
+      expect(result[:status]).to eql("enabled")
+    end
+
+    it "should use GET /automations/:id" do
+      req = double("req", perform: { id: automation_id })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("automations/#{automation_id}")
+        expect(verb).to eql("get")
+        req
+      end
+      Resend::Automations.get(automation_id)
+    end
+  end
+
+  describe "update" do
+    it "should update an automation" do
+      resp = { object: "automation", id: automation_id }
+      params = { automation_id: automation_id, status: "enabled" }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Automations.update(params)
+      expect(result[:id]).to eql(automation_id)
+    end
+
+    it "should use PATCH /automations/:id" do
+      params = { automation_id: automation_id, status: "enabled" }
+      req = double("req", perform: { id: automation_id })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("automations/#{automation_id}")
+        expect(verb).to eql("patch")
+        req
+      end
+      Resend::Automations.update(params)
+    end
+
+    it "should NOT include automation_id in the request body" do
+      params = { automation_id: automation_id, name: "Updated Name" }
+      req = double("req", perform: { id: automation_id })
+      expect(Resend::Request).to receive(:new).once do |_path, body, _verb|
+        expect(body).not_to have_key(:automation_id)
+        expect(body[:name]).to eql("Updated Name")
+        req
+      end
+      Resend::Automations.update(params)
+    end
+  end
+
+  describe "remove" do
+    it "should delete an automation" do
+      resp = { object: "automation", id: automation_id, deleted: true }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Automations.remove(automation_id)
+      expect(result[:id]).to eql(automation_id)
+      expect(result[:deleted]).to eql(true)
+    end
+
+    it "should use DELETE /automations/:id" do
+      req = double("req", perform: { id: automation_id, deleted: true })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("automations/#{automation_id}")
+        expect(verb).to eql("delete")
+        req
+      end
+      Resend::Automations.remove(automation_id)
+    end
+  end
+
+  describe "stop" do
+    it "should stop an automation" do
+      resp = { object: "automation", id: automation_id, status: "disabled" }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Automations.stop(automation_id)
+      expect(result[:id]).to eql(automation_id)
+      expect(result[:status]).to eql("disabled")
+    end
+
+    it "should use POST /automations/:id/stop" do
+      req = double("req", perform: { id: automation_id })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("automations/#{automation_id}/stop")
+        expect(verb).to eql("post")
+        req
+      end
+      Resend::Automations.stop(automation_id)
+    end
+  end
+
+  describe "list" do
+    it "should list automations" do
+      resp = {
+        object: "list",
+        has_more: false,
+        data: [
+          { id: automation_id, name: "Welcome Automation", status: "enabled", created_at: "2024-01-01T00:00:00.000Z" }
+        ]
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Automations.list
+      expect(result[:object]).to eql("list")
+      expect(result[:data].length).to eql(1)
+      expect(result[:has_more]).to eql(false)
+      expect(result[:data].first[:id]).to eql(automation_id)
+    end
+
+    it "should list automations with status filter" do
+      resp = { object: "list", has_more: false, data: [{ id: automation_id, status: "enabled" }] }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Automations.list({ status: "enabled" })
+      expect(result[:data].first[:status]).to eql("enabled")
+    end
+
+    it "should list automations with pagination params" do
+      resp = { object: "list", has_more: true, data: [{ id: automation_id }] }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Automations.list({ limit: 1 })
+      expect(result[:has_more]).to eql(true)
+    end
+
+    it "should use GET /automations" do
+      req = double("req", perform: { object: "list", data: [], has_more: false })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("automations")
+        expect(verb).to eql("get")
+        req
+      end
+      Resend::Automations.list
+    end
+  end
+
+  describe "Runs" do
+    it "should be accessible as Resend::Automations::Runs" do
+      expect(Resend::Automations::Runs).to be_a(Module)
+    end
+
+    describe "list" do
+      it "should list runs for an automation" do
+        resp = {
+          object: "list",
+          has_more: false,
+          data: [
+            {
+              id: run_id,
+              status: "completed",
+              started_at: "2024-01-01T00:00:00.000Z",
+              completed_at: "2024-01-01T00:01:00.000Z",
+              created_at: "2024-01-01T00:00:00.000Z"
+            }
+          ]
+        }
+        allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+        result = Resend::Automations::Runs.list(automation_id)
+        expect(result[:object]).to eql("list")
+        expect(result[:data].length).to eql(1)
+        expect(result[:data].first[:id]).to eql(run_id)
+        expect(result[:has_more]).to eql(false)
+      end
+
+      it "should use GET /automations/:id/runs" do
+        req = double("req", perform: { object: "list", data: [], has_more: false })
+        expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+          expect(path).to eql("automations/#{automation_id}/runs")
+          expect(verb).to eql("get")
+          req
+        end
+        Resend::Automations::Runs.list(automation_id)
+      end
+
+      it "should list runs with pagination params" do
+        resp = { object: "list", has_more: true, data: [{ id: run_id }] }
+        allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+        result = Resend::Automations::Runs.list(automation_id, { limit: 1 })
+        expect(result[:has_more]).to eql(true)
+      end
+    end
+
+    describe "get" do
+      it "should retrieve a specific run" do
+        resp = {
+          object: "automation_run",
+          id: run_id,
+          status: "completed",
+          started_at: "2024-01-01T00:00:00.000Z",
+          completed_at: "2024-01-01T00:01:00.000Z",
+          created_at: "2024-01-01T00:00:00.000Z",
+          steps: []
+        }
+        allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+        result = Resend::Automations::Runs.get(automation_id, run_id)
+        expect(result[:id]).to eql(run_id)
+        expect(result[:object]).to eql("automation_run")
+        expect(result[:status]).to eql("completed")
+      end
+
+      it "should use GET /automations/:id/runs/:run_id" do
+        req = double("req", perform: { id: run_id })
+        expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+          expect(path).to eql("automations/#{automation_id}/runs/#{run_id}")
+          expect(verb).to eql("get")
+          req
+        end
+        Resend::Automations::Runs.get(automation_id, run_id)
+      end
+    end
+  end
+end

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -1,0 +1,258 @@
+# frozen_string_literal: true
+
+RSpec.describe "Events" do
+  before do
+    Resend.configure do |config|
+      config.api_key = "re_123"
+    end
+  end
+
+  let(:event_id) { "evt_abc123" }
+  let(:event_name) { "user.signed_up" }
+
+  describe "create" do
+    it "should create an event without schema" do
+      resp = {
+        object: "event",
+        id: event_id,
+        name: event_name,
+        schema: nil,
+        created_at: "2024-01-01T00:00:00.000Z",
+        updated_at: "2024-01-01T00:00:00.000Z"
+      }
+      params = { name: event_name }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.create(params)
+      expect(result[:id]).to eql(event_id)
+      expect(result[:name]).to eql(event_name)
+      expect(result[:schema]).to be_nil
+    end
+
+    it "should create an event with schema" do
+      schema = { "plan" => "string", "trial_days" => "number", "is_enterprise" => "boolean" }
+      resp = {
+        object: "event",
+        id: event_id,
+        name: event_name,
+        schema: schema,
+        created_at: "2024-01-01T00:00:00.000Z",
+        updated_at: "2024-01-01T00:00:00.000Z"
+      }
+      params = { name: event_name, schema: schema }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.create(params)
+      expect(result[:id]).to eql(event_id)
+      expect(result[:schema]).to eql(schema)
+    end
+
+    it "should use POST /events" do
+      params = { name: event_name }
+      req = double("req", perform: { id: event_id })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("events")
+        expect(verb).to eql("post")
+        req
+      end
+      Resend::Events.create(params)
+    end
+  end
+
+  describe "get" do
+    it "should retrieve an event by ID" do
+      resp = {
+        object: "event",
+        id: event_id,
+        name: event_name,
+        schema: nil,
+        created_at: "2024-01-01T00:00:00.000Z",
+        updated_at: "2024-01-01T00:00:00.000Z"
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.get(event_id)
+      expect(result[:id]).to eql(event_id)
+      expect(result[:object]).to eql("event")
+    end
+
+    it "should retrieve an event by name" do
+      resp = {
+        object: "event",
+        id: event_id,
+        name: event_name,
+        schema: nil,
+        created_at: "2024-01-01T00:00:00.000Z",
+        updated_at: "2024-01-01T00:00:00.000Z"
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.get(event_name)
+      expect(result[:name]).to eql(event_name)
+    end
+
+    it "should use GET /events/:identifier" do
+      req = double("req", perform: { id: event_id })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("events/#{CGI.escape(event_id)}")
+        expect(verb).to eql("get")
+        req
+      end
+      Resend::Events.get(event_id)
+    end
+
+    it "should URL-encode the identifier when it is an event name" do
+      req = double("req", perform: { name: event_name })
+      expect(Resend::Request).to receive(:new).once do |path, _body, _verb|
+        expect(path).to eql("events/#{CGI.escape(event_name)}")
+        req
+      end
+      Resend::Events.get(event_name)
+    end
+  end
+
+  describe "update" do
+    it "should update an event schema" do
+      new_schema = { "plan" => "string", "upgraded_at" => "date" }
+      resp = {
+        object: "event",
+        id: event_id,
+        name: event_name,
+        schema: new_schema,
+        created_at: "2024-01-01T00:00:00.000Z",
+        updated_at: "2024-01-02T00:00:00.000Z"
+      }
+      params = { identifier: event_id, schema: new_schema }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.update(params)
+      expect(result[:schema]).to eql(new_schema)
+    end
+
+    it "should use PATCH /events/:identifier" do
+      new_schema = { "plan" => "string" }
+      params = { identifier: event_id, schema: new_schema }
+      req = double("req", perform: { id: event_id })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("events/#{CGI.escape(event_id)}")
+        expect(verb).to eql("patch")
+        req
+      end
+      Resend::Events.update(params)
+    end
+
+    it "should NOT include identifier in the request body" do
+      params = { identifier: event_id, schema: { "plan" => "string" } }
+      req = double("req", perform: { id: event_id })
+      expect(Resend::Request).to receive(:new).once do |_path, body, _verb|
+        expect(body).not_to have_key(:identifier)
+        expect(body[:schema]).to eql({ "plan" => "string" })
+        req
+      end
+      Resend::Events.update(params)
+    end
+
+    it "should accept a name-based identifier" do
+      params = { identifier: event_name, schema: nil }
+      req = double("req", perform: { id: event_id })
+      expect(Resend::Request).to receive(:new).once do |path, _body, _verb|
+        expect(path).to eql("events/#{CGI.escape(event_name)}")
+        req
+      end
+      Resend::Events.update(params)
+    end
+  end
+
+  describe "remove" do
+    it "should delete an event by ID" do
+      resp = { object: "event", id: event_id, deleted: true }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.remove(event_id)
+      expect(result[:id]).to eql(event_id)
+      expect(result[:deleted]).to eql(true)
+    end
+
+    it "should delete an event by name" do
+      resp = { object: "event", id: event_id, deleted: true }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.remove(event_name)
+      expect(result[:deleted]).to eql(true)
+    end
+
+    it "should use DELETE /events/:identifier" do
+      req = double("req", perform: { id: event_id, deleted: true })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("events/#{CGI.escape(event_id)}")
+        expect(verb).to eql("delete")
+        req
+      end
+      Resend::Events.remove(event_id)
+    end
+  end
+
+  describe "send" do
+    it "should send an event with contact_id" do
+      resp = { object: "event", event: event_name }
+      params = { event: event_name, contact_id: "contact_abc123", payload: { plan: "pro" } }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.send(params)
+      expect(result[:object]).to eql("event")
+      expect(result[:event]).to eql(event_name)
+    end
+
+    it "should send an event with email" do
+      resp = { object: "event", event: event_name }
+      params = { event: event_name, email: "user@example.com" }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.send(params)
+      expect(result[:event]).to eql(event_name)
+    end
+
+    it "should use POST /events/send" do
+      params = { event: event_name, contact_id: "contact_abc123" }
+      req = double("req", perform: { object: "event", event: event_name })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("events/send")
+        expect(verb).to eql("post")
+        req
+      end
+      Resend::Events.send(params)
+    end
+  end
+
+  describe "list" do
+    it "should list events" do
+      resp = {
+        object: "list",
+        has_more: false,
+        data: [
+          {
+            id: event_id,
+            name: event_name,
+            schema: nil,
+            created_at: "2024-01-01T00:00:00.000Z",
+            updated_at: "2024-01-01T00:00:00.000Z"
+          }
+        ]
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.list
+      expect(result[:object]).to eql("list")
+      expect(result[:data].length).to eql(1)
+      expect(result[:has_more]).to eql(false)
+      expect(result[:data].first[:id]).to eql(event_id)
+    end
+
+    it "should list events with pagination params" do
+      resp = { object: "list", has_more: true, data: [{ id: event_id }] }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Events.list({ limit: 1 })
+      expect(result[:has_more]).to eql(true)
+    end
+
+    it "should use GET /events" do
+      req = double("req", perform: { object: "list", data: [], has_more: false })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("events")
+        expect(verb).to eql("get")
+        req
+      end
+      Resend::Events.list
+    end
+  end
+end


### PR DESCRIPTION
As part of these new features, I also took the opportunity to upgrade the minimum required ruby version + CI

- Add Resend::Automations with create, get, update, remove, stop, list
- Add Resend::Automations::Runs with list and get (nested namespace)
- Add Resend::Events with create, get, update, remove, send, list
- Add specs and examples for both namespaces
- Add base64 as explicit runtime dependency (removed from Ruby 3.4 stdlib)
- Move rails to Gemfile development group, remove from gemspec
- Update Dockerfile to bundle install --without development


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Automations and Events API namespaces to build workflows and send custom events. Includes runnable examples, full RSpec coverage, Ruby 3.2+ support (tested through Ruby 4.0), and a leaner Docker image.

- **New Features**
  - `Resend::Automations`: create, get, update, remove, stop, list (status filter, pagination).
  - `Resend::Automations::Runs`: list (pagination), get.
  - `Resend::Events`: create, get (by ID or name), update, remove, send, list (pagination).
  - Added examples and RSpec tests for both namespaces.

- **Dependencies**
  - Ruby >= 3.2.
  - Added `base64` as a runtime dependency.
  - Moved `rails` to the Gemfile development group; removed from the gemspec.
  - Dockerfile installs with `--without development`.
  - Bumped gem version to 1.3.0.

<sup>Written for commit e81d8745155abdbfe53411443f54bf969518ed0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



