### PR TITLE
chore: bump version to 1.3.0

### DIFF
--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "1.2.0"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the `resend` gem version from 1.2.0 to 1.3.0 to prepare the next minor release.

<sup>Written for commit bf7cba6a8d75d217b98ea237ab26b6a87f266ec1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

