### PR TITLE
feat(domains): add TrackingCAA record support

### DIFF
--- a/spec/domains_spec.rb
+++ b/spec/domains_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe "Domains" do
             "type": "CNAME",
             "ttl": "Auto",
             "status": "not_started"
+          },
+          {
+            "record": "TrackingCAA",
+            "name": "",
+            "value": "0 issue \"amazon.com\"",
+            "type": "CAA",
+            "ttl": "Auto",
+            "status": "not_started"
           }
         ],
         "region": "us-east-1",
@@ -128,6 +136,10 @@ RSpec.describe "Domains" do
       expect(tracking_record[:type]).to eql("CNAME")
       expect(tracking_record[:ttl]).to eql("Auto")
       expect(tracking_record[:status]).to eql("not_started")
+      tracking_caa_record = domain[:records].find { |r| r[:record] == "TrackingCAA" }
+      expect(tracking_caa_record).not_to be_nil
+      expect(tracking_caa_record[:type]).to eql("CAA")
+      expect(tracking_caa_record[:value]).to eql("0 issue \"amazon.com\"")
     end
 
     it "should raise when domain is already registered" do


### PR DESCRIPTION
## Summary

The Domains API now returns an extra DNS record on `POST /domains` and `GET /domains/:id` when a tracking subdomain is configured **and** the customer's root domain has CAA records that would prevent AWS from issuing a certificate for the tracking subdomain:

```json
{
  "record": "TrackingCAA",
  "name": "",
  "type": "CAA",
  "ttl": "Auto",
  "value": "0 issue \"amazon.com\"",
  "status": "verified"
}
```

Records are returned as plain hashes in this SDK, so no source change is required — the record deserializes today. This PR extends the existing `creates a domain with tracking_subdomain` spec to include and assert on the new record.

## Test plan

- [ ] CI runs `bundle exec rspec` (local Ruby is older than the project minimum, so deferring to CI)

Tracking: [Linear ENG-4844](https://linear.app/resend/issue/ENG-4844/ruby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for returning a `TrackingCAA` DNS record when a tracking subdomain is set and the root domain’s CAA would block AWS from issuing the tracking certificate. Updates the tracking subdomain spec to cover this case (per Linear ENG-4844).

- **New Features**
  - `POST /domains` and `GET /domains/:id` may include a `TrackingCAA` record with `type: "CAA"`, `value: "0 issue \"amazon.com\""`, and `ttl: "Auto"`.
  - SDK already deserializes record hashes; no source change needed.
  - Extends the create-with-tracking-subdomain spec to assert the new record.

<sup>Written for commit fcc21f003e8e1f2899254126b6d4b373d10dcd64. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

