### PR TITLE
test(domains): pass click and open tracking params in create test

### DIFF
--- a/spec/domains_spec.rb
+++ b/spec/domains_spec.rb
@@ -121,7 +121,9 @@ RSpec.describe "Domains" do
       params = {
         "name": "example.com",
         "region": "us-east-1",
-        "tracking_subdomain": "links"
+        "tracking_subdomain": "links",
+        "click_tracking": true,
+        "open_tracking": true
       }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       domain = Resend::Domains.create(params)


### PR DESCRIPTION
## Summary
- Update domain creation test to also pass `click_tracking` and `open_tracking` in the create params, reflecting the API's support for these on create
- No code changes needed — Ruby's untyped hash params already pass through to the API

## Test plan
- [x] Verified Ruby syntax with `ruby -c`
- [ ] Run `bundle exec rspec spec/domains_spec.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the domain creation test to pass `click_tracking` and `open_tracking` in the create params, matching the API’s create support and ensuring these flags are covered. No production code changes; the params already pass through to the API.

<sup>Written for commit 1152e7b3deeaea29185bf9879f39121c6268623b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

