### PR TITLE
chore: GH Actions hardening — pin actions to SHA, add permissions and timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           - "4.0"
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,14 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Ruby ${{ matrix.ruby }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       fail-fast: false # don't fail all matrix builds if one fails
       matrix:
@@ -21,7 +25,7 @@ jobs:
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
     steps:
       - uses: actions/checkout@v6
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@6aaa311d81eba98ae12eaffbcb63296ace0efcde # v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install dependencies


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardened GitHub Actions for `resend-ruby`: pinned `actions/checkout` and `ruby/setup-ruby` to commit SHAs, set top‑level `permissions: contents: read`, and added a 15‑minute timeout to the test job. Addresses Linear DEV-664 (1 HIGH, 1 MED, 1 LOW).

<sup>Written for commit ad5ae92f96f8b392b41ad8d5eb48426a63ca3ff6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

