### PR TITLE
chore: add sync-prs-to-linear action

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -1,0 +1,24 @@
+name: Sync Open PRs to Linear
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: none
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      pull-requests: write
+      issues: write
+
+    steps:
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@6adbbae7541681ead204faab5d4e5ea9bebca4da
+        with:
+          linear-api-key: ${{ secrets.LINEAR_API_KEY }}
+          linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}
+          github-token: ${{ github.token }}


### PR DESCRIPTION
Adds the `sync-prs-to-linear` workflow to automatically sync open external contributor PRs to Linear daily.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a scheduled GitHub Actions workflow to sync open PRs to Linear each day so external contributor PRs are tracked in Linear. Fulfills ENG-4902.

- New Features
  - Runs daily at 10:00 UTC and supports manual runs via `workflow_dispatch`.
  - Uses reusable `resend/public-shared-workflows/.github/actions/sync_prs_to_linear`.
  - Requires `LINEAR_API_KEY` and `LINEAR_TEAM_ID` secrets; grants write access to PRs and Issues only.

<sup>Written for commit f6dfbc17075796b5264e844f99270384b809d37a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

