### PR TITLE
chore: bump public-shared-workflows hash

### DIFF
--- a/.github/workflows/sync-prs-to-linear.yml
+++ b/.github/workflows/sync-prs-to-linear.yml
@@ -17,7 +17,7 @@ jobs:
       issues: write
 
     steps:
-      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@3bbf3351f179ea225614e362c90a47ed2e4d07a2
+      - uses: resend/public-shared-workflows/.github/actions/sync_prs_to_linear@235fbe2ab5eff9198d18f0b4608eb0b8ddc52ede
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-id: ${{ secrets.LINEAR_TEAM_ID }}


### PR DESCRIPTION
Updates `sync_prs_to_linear` action SHA from `3bbf335` to `235fbe2`, picking up the org membership check to avoid syncing private org members to Linear.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `sync_prs_to_linear` action from `resend/public-shared-workflows` to the latest revision to include an org membership check, preventing private org members from being synced to Linear.

<sup>Written for commit 5bd139f4d6432f3b304714e551e4b588418bc8d9. Summary will update on new commits. <a href="https://cubic.dev/pr/resend/resend-ruby/pull/180?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

