### PR TITLE
feat(receiving): add html_format query param to get

### DIFF
--- a/lib/resend/emails/receiving.rb
+++ b/lib/resend/emails/receiving.rb
@@ -8,12 +8,20 @@ module Resend
         # Retrieve a single received email
         #
         # @param email_id [String] The ID of the received email
+        # @param params [Hash] Optional query parameters
+        # @option params [String] :html_format Format of the HTML content (e.g., "sanitized", "raw")
         # @return [Hash] The received email object
         #
         # @example
         #   Resend::Emails::Receiving.get("4ef9a417-02e9-4d39-ad75-9611e0fcc33c")
-        def get(email_id = "")
+        #
+        # @example With html_format
+        #   Resend::Emails::Receiving.get("4ef9a417-02e9-4d39-ad75-9611e0fcc33c", html_format: "sanitized")
+        def get(email_id = "", params = {})
           path = "emails/receiving/#{email_id}"
+
+          path += "?html_format=#{CGI.escape(params[:html_format].to_s)}" if params[:html_format]
+
           Resend::Request.new(path, {}, "get").perform
         end
 

--- a/spec/emails/receiving_spec.rb
+++ b/spec/emails/receiving_spec.rb
@@ -65,6 +65,24 @@ RSpec.describe "Emails::Receiving" do
       )
     end
 
+    it "should retrieve a received email with html_format param" do
+      resp = {
+        object: "email",
+        id: "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
+        html: "<p>sanitized</p>"
+      }
+
+      request_instance = instance_double(Resend::Request)
+      allow(request_instance).to receive(:perform).and_return(resp)
+      allow(Resend::Request).to receive(:new) do |path, body, verb|
+        expect(path).to include("html_format=sanitized")
+        request_instance
+      end
+
+      email = Resend::Emails::Receiving.get(resp[:id], html_format: "sanitized")
+      expect(email[:id]).to eql("4ef9a417-02e9-4d39-ad75-9611e0fcc33c")
+    end
+
     it "should raise an error when email is not found" do
       resp = {
         "statusCode" => 404,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add support for an optional `html_format` query param on receiving email GET requests to control HTML content format. No breaking changes; existing calls still work.

- **New Features**
  - `Resend::Emails::Receiving.get(id, params = {})` accepts `html_format` (e.g., "sanitized", "raw") and URL-encodes it into the query.
  - Spec verifies `html_format=sanitized` is sent and the response is handled correctly.

<sup>Written for commit 34702ec09ead8761890f0e8dc76d521083cc1ad0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

