### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.0] - 2026-07-09
+
+### Added
+
+- **OAuth grants** - New `Resend::OAuthGrants` module to list (`GET /oauth/grants`) and revoke (`DELETE /oauth/grants/:id`) OAuth grants. `list` supports the standard `limit`/`after`/`before` pagination params. ([#197](https://github.com/resend/resend-ruby/pull/197))
+- **Domain claims** - New `Resend::Domains::Claims` module to claim a domain verified by another account (`create`), retrieve the latest claim (`get`), and trigger verification/ownership transfer (`verify`). ([#194](https://github.com/resend/resend-ruby/pull/194))
+
 ## [1.0.0] - 2025-10-31
 
 ### Overview

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resend (1.5.0)
+    resend (1.6.0)
       base64
       httparty (>= 0.22.0)
 

--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "1.5.0"
+  VERSION = "1.6.0"
 end


### PR DESCRIPTION
Release PR for **v1.6.0**, covering the two features merged since v1.5.0.

## Changes

- Bump `Resend::VERSION` to `1.6.0` and sync the `Gemfile.lock` pin.
- Add a `CHANGELOG.md` entry for `1.6.0` (reviving the changelog, which had been dormant since 1.0.0 — scoped to this release only).

## Included in this release

- **OAuth grants** — `Resend::OAuthGrants` list + revoke (#197)
- **Domain claims** — `Resend::Domains::Claims` create/get/verify (#194)

## Release steps (post-merge)

Once merged, a maintainer with RubyGems push access runs from `main`:

```bash
bundle exec rake release
```

This builds the gem, tags `v1.6.0`, and pushes to rubygems.org.

## Testing

- `bundle exec rspec` → 310 examples, 0 failures
- `bundle exec rubocop` → no offenses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v1.6.0 of the `resend` gem, adding OAuth grant management and domain claim support. Also bumps `Resend::VERSION` and updates `CHANGELOG.md`.

- **New Features**
  - OAuth grants — `Resend::OAuthGrants` to list and revoke grants (`GET /oauth/grants`, `DELETE /oauth/grants/:id`) with `limit`/`after`/`before` pagination.
  - Domain claims — `Resend::Domains::Claims` to create, get, and verify claims for cross-account domain transfers.

<sup>Written for commit 6da10fa0d561178c22aaa17860cdcdb2befff1a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

