### PR TITLE
docs(batch): document tags support

### DIFF
--- a/lib/resend/batch.rb
+++ b/lib/resend/batch.rb
@@ -7,11 +7,10 @@ module Resend
       # Send a batch of emails
       #
       # Each email in +params+ accepts the same fields as {Resend::Emails.send},
-      # except +scheduled_at+ and +attachments+, which are not supported in batch.
-      # +tags+ are supported per email.
+      # including +tags+ per email.
       #
       # @param params [Array<Hash>] Array of email parameters (max 100 emails).
-      #   Each hash accepts the same fields as {Resend::Emails.send}, except:
+      #   Each hash accepts the same fields as {Resend::Emails.send}, including:
       #   - +tags+ [Array<Hash>] Key/value tags, e.g. [{ name: "category", value: "welcome" }]
       # @param options [Hash] Additional options for the request
       # @option options [String] :idempotency_key Optional idempotency key

--- a/lib/resend/batch.rb
+++ b/lib/resend/batch.rb
@@ -7,13 +7,12 @@ module Resend
       # Send a batch of emails
       #
       # Each email in +params+ accepts the same fields as {Resend::Emails.send},
-      # including +scheduled_at+, +tags+, and +attachments+.
+      # except +scheduled_at+ and +attachments+, which are not supported in batch.
+      # +tags+ are supported per email.
       #
       # @param params [Array<Hash>] Array of email parameters (max 100 emails).
-      #   Each hash accepts the same fields as {Resend::Emails.send}, including:
-      #   - +scheduled_at+ [String] ISO 8601 schedule time
+      #   Each hash accepts the same fields as {Resend::Emails.send}, except:
       #   - +tags+ [Array<Hash>] Key/value tags, e.g. [{ name: "category", value: "welcome" }]
-      #   - +attachments+ [Array<Hash>] File attachments with +filename+ and +content+ or +path+
       # @param options [Hash] Additional options for the request
       # @option options [String] :idempotency_key Optional idempotency key
       # @option options [String] :batch_validation Batch validation mode: "strict" (default) or "permissive"

--- a/lib/resend/batch.rb
+++ b/lib/resend/batch.rb
@@ -6,7 +6,14 @@ module Resend
     class << self
       # Send a batch of emails
       #
-      # @param params [Array<Hash>] Array of email parameters (max 100 emails)
+      # Each email in +params+ accepts the same fields as {Resend::Emails.send},
+      # including +scheduled_at+, +tags+, and +attachments+.
+      #
+      # @param params [Array<Hash>] Array of email parameters (max 100 emails).
+      #   Each hash accepts the same fields as {Resend::Emails.send}, including:
+      #   - +scheduled_at+ [String] ISO 8601 schedule time
+      #   - +tags+ [Array<Hash>] Key/value tags, e.g. [{ name: "category", value: "welcome" }]
+      #   - +attachments+ [Array<Hash>] File attachments with +filename+ and +content+ or +path+
       # @param options [Hash] Additional options for the request
       # @option options [String] :idempotency_key Optional idempotency key
       # @option options [String] :batch_validation Batch validation mode: "strict" (default) or "permissive"

--- a/spec/batch_spec.rb
+++ b/spec/batch_spec.rb
@@ -266,6 +266,52 @@ RSpec.describe "Batch" do
       expect(result[:errors][0][:message]).to include("valid email address")
     end
 
+    it "passes scheduled_at, tags, and attachments in the request body" do
+      resp = {
+        "data": [
+          { "id": "ae2014de-c168-4c61-8267-70d2662a1ce1" }
+        ]
+      }
+
+      params = [
+        {
+          from: "from@e.io",
+          to: ["email1@email.com"],
+          subject: "Scheduled with metadata",
+          html: "<p>Hello</p>",
+          scheduled_at: "2024-09-05T11:52:01.858Z",
+          tags: [
+            { name: "category", value: "welcome" }
+          ],
+          attachments: [
+            {
+              filename: "invoice.pdf",
+              content: "dGVzdA=="
+            }
+          ]
+        }
+      ]
+
+      allow(resp).to receive(:body).and_return(resp)
+      allow(HTTParty).to receive(:send).and_return(resp)
+
+      Resend::Batch.send(params)
+
+      expect(HTTParty).to have_received(:send).with(
+        :post,
+        "#{Resend::Request::BASE_URL}emails/batch",
+        {
+          headers: {
+            "Content-Type" => "application/json",
+            "Accept" => "application/json",
+            "Authorization" => "Bearer re_123",
+            "User-Agent" => "resend-ruby:#{Resend::VERSION}",
+          },
+          body: params.to_json
+        }
+      )
+    end
+
     it "sends batch email with templates" do
       resp = {
         "data": [

--- a/spec/batch_spec.rb
+++ b/spec/batch_spec.rb
@@ -266,7 +266,7 @@ RSpec.describe "Batch" do
       expect(result[:errors][0][:message]).to include("valid email address")
     end
 
-    it "passes scheduled_at, tags, and attachments in the request body" do
+    it "passes tags in the request body" do
       resp = {
         "data": [
           { "id": "ae2014de-c168-4c61-8267-70d2662a1ce1" }
@@ -277,17 +277,10 @@ RSpec.describe "Batch" do
         {
           from: "from@e.io",
           to: ["email1@email.com"],
-          subject: "Scheduled with metadata",
+          subject: "Tagged email",
           html: "<p>Hello</p>",
-          scheduled_at: "2024-09-05T11:52:01.858Z",
           tags: [
             { name: "category", value: "welcome" }
-          ],
-          attachments: [
-            {
-              filename: "invoice.pdf",
-              content: "dGVzdA=="
-            }
           ]
         }
       ]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The batch send API supports `tags` per email. This PR documents that support in the Ruby SDK.

## Changes

- Document that each batch email supports `tags`
- Add a spec verifying `tags` are serialized in the request body

## Notes

No runtime code changes were required — `Resend::Batch.send` forwards the params array as JSON via `Resend::Request`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8b56f28-73d5-447b-b8b5-3a67cee51c02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8b56f28-73d5-447b-b8b5-3a67cee51c02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents per‑email `tags` support in `Resend::Batch.send`, noting each email accepts the same fields as `Resend::Emails.send`. Adds a spec to verify `tags` are serialized in the request body; no runtime changes.

<sup>Written for commit b4884ef6f7093052ba878982d276a6089d1d438f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/200?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

