### PR TITLE
feat: add suppressions endpoints

### DIFF
--- a/examples/suppressions.rb
+++ b/examples/suppressions.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require_relative "../lib/resend"
+
+raise if ENV["RESEND_API_KEY"].nil?
+
+Resend.api_key = ENV["RESEND_API_KEY"]
+
+def suppressions
+  suppression = Resend::Suppressions.add(email: "steve.wozniak@gmail.com")
+  puts "Added suppression: #{suppression[:id]}"
+
+  # List: filter by origin and paginate.
+  list = Resend::Suppressions.list(origin: "manual", limit: 10)
+  list[:data].each do |entry|
+    puts "#{entry[:email]} suppressed by #{entry[:origin]} (source: #{entry[:source_id] || "none"})"
+  end
+
+  # Get: the path segment accepts either the suppression ID or the email address.
+  retrieved = Resend::Suppressions.get("steve.wozniak@gmail.com")
+  puts "Retrieved suppression #{retrieved[:id]} created at #{retrieved[:created_at]}"
+
+  removed = Resend::Suppressions.remove(suppression[:id])
+  puts "Removed suppression: #{removed[:deleted]}"
+end
+
+def batch_suppressions
+  added = Resend::Suppressions::Batch.add(
+    emails: ["steve.wozniak@gmail.com", "steve.jobs@gmail.com"]
+  )
+  puts "Added #{added[:data].length} suppressions"
+
+  # Remove: pass either `emails` or `ids`, never both.
+  removed = Resend::Suppressions::Batch.remove(ids: added[:data].map { |entry| entry[:id] })
+  puts "Removed #{removed[:data].length} suppressions"
+end
+
+suppressions
+batch_suppressions

--- a/examples/suppressions.rb
+++ b/examples/suppressions.rb
@@ -13,7 +13,7 @@ def suppressions
   # List: filter by origin and paginate.
   list = Resend::Suppressions.list(origin: "manual", limit: 10)
   list[:data].each do |entry|
-    puts "#{entry[:email]} suppressed by #{entry[:origin]} (source: #{entry[:source_id] || "none"})"
+    puts "#{entry["email"]} suppressed by #{entry["origin"]} (source: #{entry["source_id"] || "none"})"
   end
 
   # Get: the path segment accepts either the suppression ID or the email address.
@@ -31,7 +31,7 @@ def batch_suppressions
   puts "Added #{added[:data].length} suppressions"
 
   # Remove: pass either `emails` or `ids`, never both.
-  removed = Resend::Suppressions::Batch.remove(ids: added[:data].map { |entry| entry[:id] })
+  removed = Resend::Suppressions::Batch.remove(ids: added[:data].map { |entry| entry["id"] })
   puts "Removed #{removed[:data].length} suppressions"
 end
 

--- a/lib/resend.rb
+++ b/lib/resend.rb
@@ -7,6 +7,7 @@ require "resend/version"
 require "httparty"
 require "json"
 require "cgi"
+require "erb"
 require "resend/errors"
 require "resend/response"
 require "resend/client"
@@ -38,6 +39,8 @@ require "resend/oauth_grants"
 require "resend/automations"
 require "resend/automations/runs"
 require "resend/events"
+require "resend/suppressions"
+require "resend/suppressions/batch"
 
 # Rails
 require "resend/railtie" if defined?(Rails) && defined?(ActionMailer)

--- a/lib/resend/suppressions.rb
+++ b/lib/resend/suppressions.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Resend
+  # Suppressions API wrapper
+  module Suppressions
+    class << self
+      #
+      # Add an email address to the suppression list. Suppressed addresses are
+      # skipped by future sends. Adding an address that is already suppressed
+      # succeeds and returns the existing suppression.
+      #
+      # @param params [Hash] the parameters
+      # @option params [String] :email the email address to suppress (required).
+      #   The API lowercases and trims it.
+      #
+      # https://resend.com/docs/api-reference/suppressions/add-suppression
+      def add(params)
+        Resend::Request.new("suppressions", params, "post").perform
+      end
+
+      #
+      # Retrieve a list of suppressions. Each entry has `id`, `email`, `origin`,
+      # `source_id` and `created_at`; unlike `get`, list entries carry no `object` key.
+      #
+      # @param params [Hash] optional filtering and pagination parameters
+      # @option params [String] :origin filter by origin: 'bounce', 'complaint' or 'manual'
+      # @option params [Integer] :limit number of results to return (1-100)
+      # @option params [String] :after cursor for forward pagination
+      # @option params [String] :before cursor for backward pagination
+      #
+      # https://resend.com/docs/api-reference/suppressions/list-suppressions
+      def list(params = {})
+        path = Resend::PaginationHelper.build_paginated_path("suppressions", params)
+        Resend::Request.new(path, {}, "get").perform
+      end
+
+      #
+      # Retrieve a single suppression. The API returns 404 'Suppression not found'
+      # when the address or ID is not suppressed.
+      #
+      # @param id_or_email [String] the suppression ID or the suppressed email address (required)
+      #
+      # https://resend.com/docs/api-reference/suppressions/get-suppression
+      def get(id_or_email)
+        raise ArgumentError, "Missing required `id_or_email` field" if id_or_email.nil? || id_or_email.empty?
+
+        Resend::Request.new("suppressions/#{ERB::Util.url_encode(id_or_email)}", {}, "get").perform
+      end
+
+      #
+      # Remove a single suppression, which allows sending to that address again.
+      # The API returns 404 'Suppression not found' when the address or ID is not suppressed.
+      #
+      # @param id_or_email [String] the suppression ID or the suppressed email address (required)
+      #
+      # https://resend.com/docs/api-reference/suppressions/remove-suppression
+      def remove(id_or_email)
+        raise ArgumentError, "Missing required `id_or_email` field" if id_or_email.nil? || id_or_email.empty?
+
+        Resend::Request.new("suppressions/#{ERB::Util.url_encode(id_or_email)}", {}, "delete").perform
+      end
+    end
+  end
+end

--- a/lib/resend/suppressions/batch.rb
+++ b/lib/resend/suppressions/batch.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Resend
+  module Suppressions
+    # Suppressions Batch API wrapper
+    module Batch
+      class << self
+        #
+        # Add up to 100 email addresses to the suppression list at once. Addresses that
+        # are already suppressed come back with their existing suppression instead of failing.
+        #
+        # @param params [Hash] the parameters
+        # @option params [Array<String>] :emails the email addresses to suppress (required, 1 to 100).
+        #   The API lowercases and trims them.
+        #
+        # https://resend.com/docs/api-reference/suppressions/add-suppressions
+        def add(params)
+          Resend::Request.new("suppressions/batch/add", params, "post").perform
+        end
+
+        #
+        # Remove up to 100 suppressions at once, either by email address or by
+        # suppression ID. Provide exactly one of `emails` or `ids`.
+        #
+        # @param params [Hash] the parameters
+        # @option params [Array<String>] :emails the email addresses to remove (1 to 100)
+        # @option params [Array<String>] :ids the suppression IDs to remove (1 to 100), as UUIDs
+        #
+        # https://resend.com/docs/api-reference/suppressions/remove-suppressions
+        def remove(params)
+          emails = params[:emails]
+          ids = params[:ids]
+          raise ArgumentError, "Provide either `emails` or `ids`, but not both" if emails.nil? == ids.nil?
+
+          # The API rejects a null `emails`/`ids`, so the unused key is omitted rather than sent as nil.
+          body = emails.nil? ? { ids: ids } : { emails: emails }
+          Resend::Request.new("suppressions/batch/remove", body, "post").perform
+        end
+      end
+    end
+  end
+end

--- a/lib/resend/suppressions/batch.rb
+++ b/lib/resend/suppressions/batch.rb
@@ -28,9 +28,11 @@ module Resend
         #
         # https://resend.com/docs/api-reference/suppressions/remove-suppressions
         def remove(params)
-          emails = params[:emails]
-          ids = params[:ids]
-          raise ArgumentError, "Provide either `emails` or `ids`, but not both" if emails.nil? == ids.nil?
+          normalized = params.transform_keys(&:to_sym)
+          emails = normalized[:emails]
+          ids = normalized[:ids]
+          raise ArgumentError, "Missing required `emails` or `ids` field" if emails.nil? && ids.nil?
+          raise ArgumentError, "Provide either `emails` or `ids`, but not both" if !emails.nil? && !ids.nil?
 
           # The API rejects a null `emails`/`ids`, so the unused key is omitted rather than sent as nil.
           body = emails.nil? ? { ids: ids } : { emails: emails }

--- a/spec/suppressions_batch_spec.rb
+++ b/spec/suppressions_batch_spec.rb
@@ -107,10 +107,47 @@ RSpec.describe "Suppressions::Batch" do
       expect(body.to_json).to eql('{"emails":["steve.wozniak@gmail.com"]}')
     end
 
+    it "should accept string keyed emails" do
+      body = nil
+
+      expect(Resend::Request).to receive(:new) do |_path, request_body, _verb|
+        body = request_body
+        instance_double(Resend::Request, perform: { data: [] })
+      end
+
+      Resend::Suppressions::Batch.remove("emails" => ["steve.wozniak@gmail.com"])
+
+      expect(body).not_to have_key(:ids)
+      expect(body.to_json).to eql('{"emails":["steve.wozniak@gmail.com"]}')
+    end
+
+    it "should accept string keyed ids" do
+      body = nil
+
+      expect(Resend::Request).to receive(:new) do |_path, request_body, _verb|
+        body = request_body
+        instance_double(Resend::Request, perform: { data: [] })
+      end
+
+      Resend::Suppressions::Batch.remove("ids" => ["e169aa45-1ecf-4183-9955-b1499d5701d3"])
+
+      expect(body).not_to have_key(:emails)
+      expect(body.to_json).to eql('{"ids":["e169aa45-1ecf-4183-9955-b1499d5701d3"]}')
+    end
+
+    it "should raise when both string keyed emails and ids are given" do
+      expect do
+        Resend::Suppressions::Batch.remove(
+          "emails" => ["steve.wozniak@gmail.com"],
+          "ids" => ["e169aa45-1ecf-4183-9955-b1499d5701d3"]
+        )
+      end.to raise_error(ArgumentError, "Provide either `emails` or `ids`, but not both")
+    end
+
     it "should raise when neither emails nor ids is given" do
       expect do
         Resend::Suppressions::Batch.remove({})
-      end.to raise_error(ArgumentError, "Provide either `emails` or `ids`, but not both")
+      end.to raise_error(ArgumentError, "Missing required `emails` or `ids` field")
     end
 
     it "should raise when both emails and ids are given" do

--- a/spec/suppressions_batch_spec.rb
+++ b/spec/suppressions_batch_spec.rb
@@ -11,16 +11,16 @@ RSpec.describe "Suppressions::Batch" do
     it "should add multiple suppressions" do
       resp = {
         data: [
-          { object: "suppression", id: "e169aa45-1ecf-4183-9955-b1499d5701d3" },
-          { object: "suppression", id: "1b3d4b95-2b7d-4c5f-9b1f-2d1a5a3f8e12" }
+          { "object" => "suppression", "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3" },
+          { "object" => "suppression", "id" => "1b3d4b95-2b7d-4c5f-9b1f-2d1a5a3f8e12" }
         ]
       }
 
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Suppressions::Batch.add(emails: ["steve.wozniak@gmail.com", "steve.jobs@gmail.com"])
       expect(result[:data].length).to eql(2)
-      expect(result[:data][0][:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
-      expect(result[:data][0][:object]).to eql("suppression")
+      expect(result[:data][0]["id"]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(result[:data][0]["object"]).to eql("suppression")
     end
 
     it "should post the emails to the batch add path" do
@@ -38,20 +38,20 @@ RSpec.describe "Suppressions::Batch" do
     it "should remove multiple suppressions by email" do
       resp = {
         data: [
-          { object: "suppression", id: "e169aa45-1ecf-4183-9955-b1499d5701d3", deleted: true }
+          { "object" => "suppression", "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3", "deleted" => true }
         ]
       }
 
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Suppressions::Batch.remove(emails: ["steve.wozniak@gmail.com"])
       expect(result[:data].length).to eql(1)
-      expect(result[:data][0][:deleted]).to be(true)
+      expect(result[:data][0]["deleted"]).to be(true)
     end
 
     it "should remove multiple suppressions by id" do
       resp = {
         data: [
-          { object: "suppression", id: "e169aa45-1ecf-4183-9955-b1499d5701d3", deleted: true }
+          { "object" => "suppression", "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3", "deleted" => true }
         ]
       }
 
@@ -63,7 +63,7 @@ RSpec.describe "Suppressions::Batch" do
 
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Suppressions::Batch.remove(ids: ["e169aa45-1ecf-4183-9955-b1499d5701d3"])
-      expect(result[:data][0][:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(result[:data][0]["id"]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
     end
 
     it "should omit ids from the request body when removing by email" do

--- a/spec/suppressions_batch_spec.rb
+++ b/spec/suppressions_batch_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suppressions::Batch" do
+  before do
+    Resend.configure do |config|
+      config.api_key = "re_123"
+    end
+  end
+
+  describe "add" do
+    it "should add multiple suppressions" do
+      resp = {
+        data: [
+          { object: "suppression", id: "e169aa45-1ecf-4183-9955-b1499d5701d3" },
+          { object: "suppression", id: "1b3d4b95-2b7d-4c5f-9b1f-2d1a5a3f8e12" }
+        ]
+      }
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Suppressions::Batch.add(emails: ["steve.wozniak@gmail.com", "steve.jobs@gmail.com"])
+      expect(result[:data].length).to eql(2)
+      expect(result[:data][0][:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(result[:data][0][:object]).to eql("suppression")
+    end
+
+    it "should post the emails to the batch add path" do
+      resp = { data: [] }
+
+      params = { emails: ["steve.wozniak@gmail.com"] }
+
+      expect(Resend::Request).to receive(:new).with("suppressions/batch/add", params, "post").and_call_original
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      Resend::Suppressions::Batch.add(params)
+    end
+  end
+
+  describe "remove" do
+    it "should remove multiple suppressions by email" do
+      resp = {
+        data: [
+          { object: "suppression", id: "e169aa45-1ecf-4183-9955-b1499d5701d3", deleted: true }
+        ]
+      }
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Suppressions::Batch.remove(emails: ["steve.wozniak@gmail.com"])
+      expect(result[:data].length).to eql(1)
+      expect(result[:data][0][:deleted]).to be(true)
+    end
+
+    it "should remove multiple suppressions by id" do
+      resp = {
+        data: [
+          { object: "suppression", id: "e169aa45-1ecf-4183-9955-b1499d5701d3", deleted: true }
+        ]
+      }
+
+      expect(Resend::Request).to receive(:new).with(
+        "suppressions/batch/remove",
+        { ids: ["e169aa45-1ecf-4183-9955-b1499d5701d3"] },
+        "post"
+      ).and_call_original
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Suppressions::Batch.remove(ids: ["e169aa45-1ecf-4183-9955-b1499d5701d3"])
+      expect(result[:data][0][:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+    end
+
+    it "should omit ids from the request body when removing by email" do
+      body = nil
+
+      expect(Resend::Request).to receive(:new) do |_path, request_body, _verb|
+        body = request_body
+        instance_double(Resend::Request, perform: { data: [] })
+      end
+
+      Resend::Suppressions::Batch.remove(emails: ["steve.wozniak@gmail.com"])
+
+      expect(body).not_to have_key(:ids)
+      expect(body.to_json).to eql('{"emails":["steve.wozniak@gmail.com"]}')
+    end
+
+    it "should omit emails from the request body when removing by id" do
+      body = nil
+
+      expect(Resend::Request).to receive(:new) do |_path, request_body, _verb|
+        body = request_body
+        instance_double(Resend::Request, perform: { data: [] })
+      end
+
+      Resend::Suppressions::Batch.remove(ids: ["e169aa45-1ecf-4183-9955-b1499d5701d3"])
+
+      expect(body).not_to have_key(:emails)
+      expect(body.to_json).to eql('{"ids":["e169aa45-1ecf-4183-9955-b1499d5701d3"]}')
+    end
+
+    it "should ignore an explicitly nil ids and send only emails" do
+      body = nil
+
+      expect(Resend::Request).to receive(:new) do |_path, request_body, _verb|
+        body = request_body
+        instance_double(Resend::Request, perform: { data: [] })
+      end
+
+      Resend::Suppressions::Batch.remove(emails: ["steve.wozniak@gmail.com"], ids: nil)
+
+      expect(body.to_json).to eql('{"emails":["steve.wozniak@gmail.com"]}')
+    end
+
+    it "should raise when neither emails nor ids is given" do
+      expect do
+        Resend::Suppressions::Batch.remove({})
+      end.to raise_error(ArgumentError, "Provide either `emails` or `ids`, but not both")
+    end
+
+    it "should raise when both emails and ids are given" do
+      expect do
+        Resend::Suppressions::Batch.remove(
+          emails: ["steve.wozniak@gmail.com"],
+          ids: ["e169aa45-1ecf-4183-9955-b1499d5701d3"]
+        )
+      end.to raise_error(ArgumentError, "Provide either `emails` or `ids`, but not both")
+    end
+  end
+end

--- a/spec/suppressions_spec.rb
+++ b/spec/suppressions_spec.rb
@@ -1,0 +1,212 @@
+# frozen_string_literal: true
+
+RSpec.describe "Suppressions" do
+  before do
+    Resend.configure do |config|
+      config.api_key = "re_123"
+    end
+  end
+
+  describe "add" do
+    it "should add a suppression" do
+      resp = {
+        object: "suppression",
+        id: "e169aa45-1ecf-4183-9955-b1499d5701d3"
+      }
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      suppression = Resend::Suppressions.add(email: "steve.wozniak@gmail.com")
+      expect(suppression[:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(suppression[:object]).to eql("suppression")
+    end
+
+    it "should post the email to the suppressions path" do
+      resp = { object: "suppression", id: "e169aa45-1ecf-4183-9955-b1499d5701d3" }
+
+      params = { email: "steve.wozniak@gmail.com" }
+
+      expect(Resend::Request).to receive(:new).with("suppressions", params, "post").and_call_original
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      Resend::Suppressions.add(params)
+    end
+  end
+
+  describe "list" do
+    it "should list suppressions" do
+      resp = {
+        object: "list",
+        has_more: false,
+        data: [
+          {
+            id: "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            email: "steve.wozniak@gmail.com",
+            origin: "bounce",
+            source_id: "479e3145-dd38-476b-932c-529ceb705947",
+            created_at: "2023-10-06T23:47:56.678Z"
+          }
+        ]
+      }
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Suppressions.list
+      expect(result[:object]).to eql("list")
+      expect(result[:has_more]).to be(false)
+      expect(result[:data].length).to eql(1)
+      expect(result[:data][0][:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(result[:data][0][:origin]).to eql("bounce")
+      expect(result[:data][0][:source_id]).to eql("479e3145-dd38-476b-932c-529ceb705947")
+      expect(result[:data][0][:created_at]).to eql("2023-10-06T23:47:56.678Z")
+    end
+
+    it "should not expose an object field on list entries" do
+      resp = {
+        object: "list",
+        has_more: false,
+        data: [
+          {
+            id: "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            email: "steve.wozniak@gmail.com",
+            origin: "bounce",
+            source_id: "479e3145-dd38-476b-932c-529ceb705947",
+            created_at: "2023-10-06T23:47:56.678Z"
+          }
+        ]
+      }
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Suppressions.list
+      expect(result[:data][0]).not_to have_key(:object)
+      expect(result[:data][0].keys).to eql(%i[id email origin source_id created_at])
+    end
+
+    it "should list suppressions with a null source_id" do
+      resp = {
+        object: "list",
+        has_more: false,
+        data: [
+          {
+            id: "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            email: "steve.wozniak@gmail.com",
+            origin: "manual",
+            source_id: nil,
+            created_at: "2023-10-06T23:47:56.678Z"
+          }
+        ]
+      }
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Suppressions.list
+      expect(result[:data][0][:origin]).to eql("manual")
+      expect(result[:data][0][:source_id]).to be_nil
+    end
+
+    it "should list suppressions with origin and pagination params" do
+      resp = { object: "list", has_more: false, data: [] }
+
+      expect(Resend::Request).to receive(:new).with(
+        "suppressions?origin=bounce&limit=10&after=e169aa45-1ecf-4183-9955-b1499d5701d3",
+        {},
+        "get"
+      ).and_call_original
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      Resend::Suppressions.list(origin: "bounce", limit: 10, after: "e169aa45-1ecf-4183-9955-b1499d5701d3")
+    end
+  end
+
+  describe "get" do
+    it "should retrieve a suppression by id" do
+      resp = {
+        object: "suppression",
+        id: "e169aa45-1ecf-4183-9955-b1499d5701d3",
+        email: "steve.wozniak@gmail.com",
+        origin: "complaint",
+        source_id: "479e3145-dd38-476b-932c-529ceb705947",
+        created_at: "2023-10-06T23:47:56.678Z"
+      }
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      suppression = Resend::Suppressions.get("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(suppression[:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(suppression[:email]).to eql("steve.wozniak@gmail.com")
+      expect(suppression[:origin]).to eql("complaint")
+      expect(suppression[:created_at]).to eql("2023-10-06T23:47:56.678Z")
+      expect(suppression[:object]).to eql("suppression")
+    end
+
+    it "should retrieve a suppression with a null source_id" do
+      resp = {
+        object: "suppression",
+        id: "e169aa45-1ecf-4183-9955-b1499d5701d3",
+        email: "steve.wozniak@gmail.com",
+        origin: "manual",
+        source_id: nil,
+        created_at: "2023-10-06T23:47:56.678Z"
+      }
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      suppression = Resend::Suppressions.get("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(suppression[:origin]).to eql("manual")
+      expect(suppression[:source_id]).to be_nil
+    end
+
+    it "should url encode an email address in the path" do
+      resp = { object: "suppression", id: "e169aa45-1ecf-4183-9955-b1499d5701d3" }
+
+      expect(Resend::Request).to receive(:new).with(
+        "suppressions/steve.wozniak%2Bnews%40gmail.com",
+        {},
+        "get"
+      ).and_call_original
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      Resend::Suppressions.get("steve.wozniak+news@gmail.com")
+    end
+
+    it "should raise when id_or_email is missing" do
+      expect do
+        Resend::Suppressions.get("")
+      end.to raise_error(ArgumentError, "Missing required `id_or_email` field")
+    end
+  end
+
+  describe "remove" do
+    it "should remove a suppression by id" do
+      resp = {
+        object: "suppression",
+        id: "e169aa45-1ecf-4183-9955-b1499d5701d3",
+        deleted: true
+      }
+
+      expect(Resend::Request).to receive(:new).with(
+        "suppressions/e169aa45-1ecf-4183-9955-b1499d5701d3",
+        {},
+        "delete"
+      ).and_call_original
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      result = Resend::Suppressions.remove("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(result[:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(result[:deleted]).to be(true)
+    end
+
+    it "should url encode an email address in the path" do
+      resp = { object: "suppression", id: "e169aa45-1ecf-4183-9955-b1499d5701d3", deleted: true }
+
+      expect(Resend::Request).to receive(:new).with(
+        "suppressions/steve.wozniak%2Bnews%40gmail.com",
+        {},
+        "delete"
+      ).and_call_original
+
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      Resend::Suppressions.remove("steve.wozniak+news@gmail.com")
+    end
+
+    it "should raise when id_or_email is missing" do
+      expect do
+        Resend::Suppressions.remove(nil)
+      end.to raise_error(ArgumentError, "Missing required `id_or_email` field")
+    end
+  end
+end

--- a/spec/suppressions_spec.rb
+++ b/spec/suppressions_spec.rb
@@ -38,11 +38,11 @@ RSpec.describe "Suppressions" do
         has_more: false,
         data: [
           {
-            id: "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            email: "steve.wozniak@gmail.com",
-            origin: "bounce",
-            source_id: "479e3145-dd38-476b-932c-529ceb705947",
-            created_at: "2023-10-06T23:47:56.678Z"
+            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "steve.wozniak@gmail.com",
+            "origin" => "bounce",
+            "source_id" => "479e3145-dd38-476b-932c-529ceb705947",
+            "created_at" => "2023-10-06T23:47:56.678Z"
           }
         ]
       }
@@ -52,10 +52,10 @@ RSpec.describe "Suppressions" do
       expect(result[:object]).to eql("list")
       expect(result[:has_more]).to be(false)
       expect(result[:data].length).to eql(1)
-      expect(result[:data][0][:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
-      expect(result[:data][0][:origin]).to eql("bounce")
-      expect(result[:data][0][:source_id]).to eql("479e3145-dd38-476b-932c-529ceb705947")
-      expect(result[:data][0][:created_at]).to eql("2023-10-06T23:47:56.678Z")
+      expect(result[:data][0]["id"]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(result[:data][0]["origin"]).to eql("bounce")
+      expect(result[:data][0]["source_id"]).to eql("479e3145-dd38-476b-932c-529ceb705947")
+      expect(result[:data][0]["created_at"]).to eql("2023-10-06T23:47:56.678Z")
     end
 
     it "should not expose an object field on list entries" do
@@ -64,19 +64,19 @@ RSpec.describe "Suppressions" do
         has_more: false,
         data: [
           {
-            id: "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            email: "steve.wozniak@gmail.com",
-            origin: "bounce",
-            source_id: "479e3145-dd38-476b-932c-529ceb705947",
-            created_at: "2023-10-06T23:47:56.678Z"
+            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "steve.wozniak@gmail.com",
+            "origin" => "bounce",
+            "source_id" => "479e3145-dd38-476b-932c-529ceb705947",
+            "created_at" => "2023-10-06T23:47:56.678Z"
           }
         ]
       }
 
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Suppressions.list
-      expect(result[:data][0]).not_to have_key(:object)
-      expect(result[:data][0].keys).to eql(%i[id email origin source_id created_at])
+      expect(result[:data][0]).not_to have_key("object")
+      expect(result[:data][0].keys).to eql(%w[id email origin source_id created_at])
     end
 
     it "should list suppressions with a null source_id" do
@@ -85,19 +85,19 @@ RSpec.describe "Suppressions" do
         has_more: false,
         data: [
           {
-            id: "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            email: "steve.wozniak@gmail.com",
-            origin: "manual",
-            source_id: nil,
-            created_at: "2023-10-06T23:47:56.678Z"
+            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "steve.wozniak@gmail.com",
+            "origin" => "manual",
+            "source_id" => nil,
+            "created_at" => "2023-10-06T23:47:56.678Z"
           }
         ]
       }
 
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Suppressions.list
-      expect(result[:data][0][:origin]).to eql("manual")
-      expect(result[:data][0][:source_id]).to be_nil
+      expect(result[:data][0]["origin"]).to eql("manual")
+      expect(result[:data][0]["source_id"]).to be_nil
     end
 
     it "should list suppressions with origin and pagination params" do


### PR DESCRIPTION
## What

Adds suppression-list support: `add`, `list`, `get`, `remove`, plus `Resend::Suppressions::Batch` with `add` / `remove`.

```ruby
Resend::Suppressions.add(email: "...")
Resend::Suppressions.list(origin: "manual", limit: 10)
Resend::Suppressions.get(id_or_email)
Resend::Suppressions.remove(id_or_email)
Resend::Suppressions::Batch.add(emails: [...])
Resend::Suppressions::Batch.remove(ids: [...])   # or emails:
```

Follows `lib/resend/domains/claims.rb` and `lib/resend/contacts/imports.rb` for the nested-module layout, `Resend::PaginationHelper` for `list`, and paths without a leading slash like its siblings. `ERB::Util.url_encode` for the id-or-email segment (`CGI.escape` is form encoding and wrong for a path segment), which required adding `require "erb"` alongside the existing `require "cgi"`.

`Batch.remove` raises `ArgumentError` unless exactly one of `emails`/`ids` is given, and builds the body with only the provided key so an explicit `nil` is never serialized as `null`.

## Contract verification

Verified in order of authority: the API server implementation (`apps/public-api/src/routes/suppressions/` in the monorepo), then `resend-openapi` `resend.yaml`, then the docs — and finally end-to-end against the live API with a real team key (read-only operations).

**One deliberate divergence, flagged so it does not look like a bug in review:** list entries do **not** carry the `object` field; only the single-`get` response does. `list.ts` selects exactly `{id, email, origin, source_id, created_at}` and adds nothing, while `get.ts` returns `{object: "suppression", ...}`. Confirmed on live wire output.

Two upstream artifacts disagree with the server here and are being tracked separately, so please do not use them as the reference when reviewing:

* the `list-suppressions` docs example shows a per-entry `object` that the API never sends
* `resend-node` `SuppressionListEntry` declares the same nonexistent field, and is shipped in `resend@6.18.0`

The OpenAPI spec is correct on this point and agrees with the implementation.

Other behaviour confirmed at the server and reflected in docs/tests, not reimplemented client-side:

* `batch/remove` accepts `emails` XOR `ids`; the unset key must be **omitted**, since the server validation accepts undefined but rejects an explicit `null`
* the API lowercases, trims and **deduplicates** emails, and `batch/add` upserts — so batch responses can contain **fewer** entries than were sent; callers must not pair results to inputs by index
* `batch/remove` returns only rows actually deleted (misses are absent, no error), whereas single `remove` returns 404 on a miss
* `source_id` is nullable and is `null` for `manual`-origin suppressions

## Release timing

These endpoints are in beta and gated behind a server-side feature flag: a team without access receives **404 on every suppression endpoint**. Merging is safe, but worth a deliberate decision on whether this ships in the next release or waits for wider flag rollout, since otherwise a documented SDK method returns 404 for most users.

## Verification

```
bundle exec rubocop   -> 39 files inspected, no offenses detected
bundle exec rake spec -> 332 examples, 0 failures
```

Run on Ruby 3.4 (a CI matrix version). 22 of those examples cover suppressions, including a guard pinning the exact list-entry key set so it cannot drift back toward the docs' shape.

**One reviewer note:** the new specs stub `Resend::Request#perform` with Symbol-keyed hashes, matching every other spec file in this repo. That is deliberate for consistency, but it does mean the fixtures do not reflect that real HTTP returns **String** keys for entries nested in `data`. That is a pre-existing, repo-wide issue rather than something introduced here, and it is filed separately as resend/resend-ruby#206.

---

## Summary by cubic

Adds suppression-list support to the Ruby SDK with single and batch endpoints to add, list, get, and remove suppressed emails. This feature is beta and behind a server flag; teams without access will receive 404s.

* **New Features**
  * Added `Resend::Suppressions.add`, `.list`, `.get`, `.remove`.
  * Added `Resend::Suppressions::Batch.add` and `.remove` (pass either `emails` or `ids`; the unused key is omitted).
  * `.list` uses `Resend::PaginationHelper`; list entries omit `object` while `.get` includes it.
  * Path segments for `id_or_email` are URL-encoded via `ERB::Util.url_encode` (added `require "erb"`). Included `examples/suppressions.rb` and new specs.
* **Bug Fixes**
  * `Resend::Suppressions::Batch.remove` now accepts string- or symbol-keyed params and raises clearer errors for missing vs. both `emails` and `ids`.
  * Use string keys for nested suppression entries in examples and specs to match real responses; top-level keys remain Symbols.

Written for commit 6930b83e894196701b87253f68121b5fbafc4d13. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)