### PR TITLE
fix(errors): map 404 to NotFoundError instead of InvalidRequestError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- ⚠️ **404 responses now raise `Resend::Error::NotFoundError`** instead of `Resend::Error::InvalidRequestError`, matching the documented intent of the (previously unreachable) `NotFoundError` class. Code rescuing `Resend::Error` or `Resend::Error::ServerError` is unaffected; code rescuing `InvalidRequestError` specifically to catch 404s should rescue `NotFoundError` instead. ([#209](https://github.com/resend/resend-ruby/issues/209))
+
 ## [1.6.0] - 2026-07-09
 
 ### Added

--- a/lib/resend/errors.rb
+++ b/lib/resend/errors.rb
@@ -34,7 +34,7 @@ module Resend
 
     ERRORS = {
       401 => Resend::Error::InvalidRequestError,
-      404 => Resend::Error::InvalidRequestError,
+      404 => Resend::Error::NotFoundError,
       422 => Resend::Error::InvalidRequestError,
       429 => Resend::Error::RateLimitExceededError,
       400 => Resend::Error::InvalidRequestError,

--- a/spec/emails/attachments_spec.rb
+++ b/spec/emails/attachments_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe "Emails::Attachments" do
           email_id: "invalid_email_id"
         )
       }.to raise_error(
-        Resend::Error::InvalidRequestError,
+        Resend::Error::NotFoundError,
         /Attachment not found/
       )
     end

--- a/spec/emails/receiving/attachments_spec.rb
+++ b/spec/emails/receiving/attachments_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe "Emails::Receiving::Attachments" do
           email_id: "invalid_email_id"
         )
       }.to raise_error(
-        Resend::Error::InvalidRequestError,
+        Resend::Error::NotFoundError,
         /Attachment not found/
       )
     end

--- a/spec/emails/receiving_spec.rb
+++ b/spec/emails/receiving_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "Emails::Receiving" do
       allow(HTTParty).to receive(:send).and_return(resp)
 
       expect { Resend::Emails::Receiving.get("invalid_id") }.to raise_error(
-        Resend::Error::InvalidRequestError,
+        Resend::Error::NotFoundError,
         /Email not found/
       )
     end

--- a/spec/logs_spec.rb
+++ b/spec/logs_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Logs" do
         }
         allow(resp).to receive(:body).and_return(resp)
         allow(HTTParty).to receive(:send).and_return(resp)
-        expect { Resend::Logs.get("missing-id") }.to raise_error(Resend::Error::InvalidRequestError, /Log not found/)
+        expect { Resend::Logs.get("missing-id") }.to raise_error(Resend::Error::NotFoundError, /Log not found/)
       end
 
       it "should raise when log_id is not a valid UUID" do

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -68,6 +68,15 @@ RSpec.describe Resend::Request do
       expect { req.handle_error!(resp) }.to raise_error(Resend::Error::InvalidRequestError, /422/)
     end
 
+    it "Resend::Error::NotFoundError 404" do
+      req = described_class.new
+      resp = {
+        :statusCode => 404,
+        :message => "404"
+      }
+      expect { req.handle_error!(resp) }.to raise_error(Resend::Error::NotFoundError, /404/)
+    end
+
     it "Resend::Error::RateLimitExceededError 429 with headers" do
       req = described_class.new
       resp = {

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Webhooks" do
       allow(resp).to receive(:body).and_return(resp.to_json)
       allow(HTTParty).to receive(:send).and_return(resp)
 
-      expect { Resend::Webhooks.get("invalid-id") }.to raise_error(Resend::Error::InvalidRequestError)
+      expect { Resend::Webhooks.get("invalid-id") }.to raise_error(Resend::Error::NotFoundError)
     end
   end
 
@@ -223,7 +223,7 @@ RSpec.describe "Webhooks" do
       allow(resp).to receive(:body).and_return(resp.to_json)
       allow(HTTParty).to receive(:send).and_return(resp)
 
-      expect { Resend::Webhooks.remove("invalid-id") }.to raise_error(Resend::Error::InvalidRequestError)
+      expect { Resend::Webhooks.remove("invalid-id") }.to raise_error(Resend::Error::NotFoundError)
     end
   end
 


### PR DESCRIPTION
Fixes #209

## What

`Resend::Error::NotFoundError` is defined and commented as the 404 error, but `ERRORS` mapped 404 to `InvalidRequestError`, so `NotFoundError` was unreachable and `rescue Resend::Error::NotFoundError` never matched.

This maps 404 to `NotFoundError`, matching the documented intent. `NotFoundError` subclasses `ServerError` just like `InvalidRequestError`, so code rescuing `ServerError` or `Resend::Error` is unaffected. Code rescuing `InvalidRequestError` specifically to catch 404s is the one breaking case; noted in the changelog.

## Changes

- `lib/resend/errors.rb`: `404 => Resend::Error::NotFoundError`
- existing specs asserting `InvalidRequestError` on 404 responses updated (logs, webhooks, emails, attachments)
- new `handle_error!` spec for the 404 -> `NotFoundError` mapping
- changelog entry under Unreleased flagging the behavior change

Credit to @felipefreitag for the report in #209.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Map HTTP 404 responses to `Resend::Error::NotFoundError` instead of `Resend::Error::InvalidRequestError`, making the documented `NotFoundError` reachable. Tests and changelog updated; generic error handling remains the same.

- **Migration**
  - If you rescued `Resend::Error::InvalidRequestError` for 404s, switch to `Resend::Error::NotFoundError`.
  - No changes needed if you rescue `Resend::Error` or `Resend::Error::ServerError`.

<sup>Written for commit 398ad0d162b60afa96458c177282e9405c16a24d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/210?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

