### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.7.0] - 2026-07-31
+
+### Added
+
+- **Suppressions** - New `Resend::Suppressions` module to add (`add`), list (`list`), retrieve (`get`), and remove (`remove`) suppressed email addresses. `get` and `remove` accept either a suppression ID or the suppressed email address. `list` supports `origin` filtering (`bounce`, `complaint`, `manual`) plus the standard `limit`/`after`/`before` pagination params. New `Resend::Suppressions::Batch` module handles up to 100 addresses at a time via `add` and `remove`. ([#208](https://github.com/resend/resend-ruby/pull/208))
 
 ### Changed
 
-- ⚠️ **404 responses now raise `Resend::Error::NotFoundError`** instead of `Resend::Error::InvalidRequestError`, matching the documented intent of the (previously unreachable) `NotFoundError` class. Code rescuing `Resend::Error` or `Resend::Error::ServerError` is unaffected; code rescuing `InvalidRequestError` specifically to catch 404s should rescue `NotFoundError` instead. ([#209](https://github.com/resend/resend-ruby/issues/209))
+- ⚠️ **404 responses now raise `Resend::Error::NotFoundError`** instead of `Resend::Error::InvalidRequestError`, matching the documented intent of the (previously unreachable) `NotFoundError` class. Code rescuing `Resend::Error` or `Resend::Error::ServerError` is unaffected; code rescuing `InvalidRequestError` specifically to catch 404s should rescue `NotFoundError` instead. ([#210](https://github.com/resend/resend-ruby/pull/210))
 
 ## [1.6.0] - 2026-07-09
 
@@ -141,4 +145,6 @@ Resend::Segments.remove("segment_123")
 
 - Remove deprecated `send_email` method from `Resend::Emails` module (use `Resend::Emails.send` instead)
 
+[1.7.0]: https://github.com/resend/resend-ruby/compare/v1.6.0...v1.7.0
+[1.6.0]: https://github.com/resend/resend-ruby/compare/v1.5.0...v1.6.0
 [1.0.0]: https://github.com/resend/resend-ruby/compare/v0.26.0...v1.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resend (1.6.0)
+    resend (1.7.0)
       base64
       httparty (>= 0.22.0)
 

--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end


### PR DESCRIPTION
Stacked on #210. Merge #210 first, then this.

## What

Cuts 1.7.0 with the suppressions endpoints (#208) and the 404 error mapping (#210).

## Changes

- `CHANGELOG.md` — promote the `## [Unreleased]` heading from #210 to `## [1.7.0] - 2026-07-31`, and add the suppressions entry above the existing `### Changed` block. Repoint the 404 link from issue #209 to PR #210, to match how the 1.6.0 entries link PRs.
- `CHANGELOG.md` — add the missing compare-link definitions for `[1.7.0]` and `[1.6.0]`. Only `[1.0.0]` had one, so the 1.6.0 heading has rendered as literal brackets since it was added.
- `lib/resend/version.rb` — `1.6.0` -> `1.7.0`
- `Gemfile.lock` — `resend (1.6.0)` -> `resend (1.7.0)`

## Version choice

1.7.0, not 2.0.0.

The 404 change is breaking for code that rescues `InvalidRequestError` specifically to catch 404s, so strict SemVer points at a major. The blast radius is narrow: `NotFoundError` and `InvalidRequestError` share the `ServerError` parent, so anything rescuing `Resend::Error` or `ServerError` is unaffected.

A major bump signals a rewrite. 1.0.0 was a genuine Contacts API redesign. The `Resend::Error::ClientError` hierarchy fix is the change that warrants 2.0.0 — see the follow-up note below.

The ⚠️ changelog entry carries the migration instruction.

## Follow-up, not in this PR

`Resend::Error::ClientError` (`lib/resend/errors.rb:8`) is referenced nowhere in the repo. Every 4xx code — 400, 401, 404, 422, 429 — subclasses `ServerError` instead. That inverted hierarchy is the root cause of #209: `NotFoundError` was unreachable because the tree was never wired up. `401 => InvalidRequestError` has the same problem, with no auth-specific class.

Reparenting the 4xx classes is a real breaking change and belongs in 2.0.0.

## Verification

Ran in a `ruby:3.4` container, since the gem requires >= 3.2:

- `bundle exec rspec` — 336 examples, 0 failures
- `bundle exec rubocop` — 39 files, no offenses
- `Resend::VERSION` resolves to `1.7.0`

## Before publishing

Put the ⚠️ migration note in the GitHub release body. Auto-generated notes render #210 as `fix(errors): map 404 to NotFoundError by @Mohith26 in #210`, which does not warn anyone upgrading for suppressions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cut `resend` v1.7.0 with the suppressions API, 404 -> NotFoundError mapping, and changelog compare-link fixes.

- **New Features**
  - Suppressions API: add, list, get, and remove suppressed emails, plus batch add/remove (up to 100).

- **Migration**
  - If you rescue InvalidRequestError for 404s, change to NotFoundError. Rescuing Resend::Error or ServerError is unaffected.

<sup>Written for commit 9264ee5e9f9fe57f9bd1aae2c3bf2112ffeea9d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/213?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

