### PR TITLE
chore: use the API timestamp format in spec fixtures

### DIFF
--- a/spec/api_keys_spec.rb
+++ b/spec/api_keys_spec.rb
@@ -45,20 +45,20 @@ RSpec.describe "API Keys" do
             {
               "id":"6e3c3d83-05dc-4b51-acfc-fe8972738bd0",
               "name":"test1",
-              "created_at":"2023-04-21T01:31:02.671414+00:00",
-              "last_used_at":"2023-04-22T10:00:00.000000+00:00"
+              "created_at":"2023-04-21 01:31:02.671414+00",
+              "last_used_at":"2023-04-22 10:00:00+00"
             },
             {
               "id":"7f4d4e94-16ed-5c62-bdfd-gf9083849ce1",
               "name":"test2",
-              "created_at":"2023-04-21T01:31:02.671414+00:00",
+              "created_at":"2023-04-21 01:31:02.671414+00",
               "last_used_at":nil
             }
           ]
         }
         allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
         expect(Resend::ApiKeys.list[:data].length).to eql(2)
-        expect(Resend::ApiKeys.list[:data].first[:last_used_at]).to eql("2023-04-22T10:00:00.000000+00:00")
+        expect(Resend::ApiKeys.list[:data].first[:last_used_at]).to eql("2023-04-22 10:00:00+00")
         expect(Resend::ApiKeys.list[:data].last[:last_used_at]).to be_nil
       end
     end
@@ -115,20 +115,20 @@ RSpec.describe "API Keys" do
             {
               "id":"6e3c3d83-05dc-4b51-acfc-fe8972738bd0",
               "name":"test1",
-              "created_at":"2023-04-21T01:31:02.671414+00:00",
-              "last_used_at":"2023-04-22T10:00:00.000000+00:00"
+              "created_at":"2023-04-21 01:31:02.671414+00",
+              "last_used_at":"2023-04-22 10:00:00+00"
             },
             {
               "id":"7f4d4e94-16ed-5c62-bdfd-gf9083849ce1",
               "name":"test2",
-              "created_at":"2023-04-21T01:31:02.671414+00:00",
+              "created_at":"2023-04-21 01:31:02.671414+00",
               "last_used_at":nil
             }
           ]
         }
         allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
         expect(Resend::ApiKeys.list[:data].length).to eql(2)
-        expect(Resend::ApiKeys.list[:data].first[:last_used_at]).to eql("2023-04-22T10:00:00.000000+00:00")
+        expect(Resend::ApiKeys.list[:data].first[:last_used_at]).to eql("2023-04-22 10:00:00+00")
         expect(Resend::ApiKeys.list[:data].last[:last_used_at]).to be_nil
       end
     end

--- a/spec/audiences_spec.rb
+++ b/spec/audiences_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Audiences" do
         "object": "audience",
         "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
         "name": "Registered Users",
-        "created_at": "2023-10-06T22:59:55.977Z"
+        "created_at": "2023-10-06 22:59:55.977+00"
       }
       allow(resp).to receive(:body).and_return(resp)
       allow(HTTParty).to receive(:send).and_return(resp)
@@ -43,7 +43,7 @@ RSpec.describe "Audiences" do
       expect(audience[:object]).to eql "audience"
       expect(audience[:id]).to eql "78261eea-8f8b-4381-83c6-79fa7120f1cf"
       expect(audience[:name]).to eql "Registered Users"
-      expect(audience[:created_at]).to eql "2023-10-06T22:59:55.977Z"
+      expect(audience[:created_at]).to eql "2023-10-06 22:59:55.977+00"
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe "Audiences" do
           {
             "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "name": "Registered Users",
-            "created_at": "2023-10-06T22:59:55.977Z"
+            "created_at": "2023-10-06 22:59:55.977+00"
           }
         ]
       }

--- a/spec/automations_spec.rb
+++ b/spec/automations_spec.rb
@@ -53,8 +53,8 @@ RSpec.describe "Automations" do
         id: automation_id,
         name: "Welcome Automation",
         status: "enabled",
-        created_at: "2024-01-01T00:00:00.000Z",
-        updated_at: "2024-01-01T00:00:00.000Z",
+        created_at: "2024-01-01 00:00:00+00",
+        updated_at: "2024-01-01 00:00:00+00",
         steps: steps,
         connections: connections
       }
@@ -155,7 +155,7 @@ RSpec.describe "Automations" do
         object: "list",
         has_more: false,
         data: [
-          { id: automation_id, name: "Welcome Automation", status: "enabled", created_at: "2024-01-01T00:00:00.000Z" }
+          { id: automation_id, name: "Welcome Automation", status: "enabled", created_at: "2024-01-01 00:00:00+00" }
         ]
       }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
@@ -205,9 +205,9 @@ RSpec.describe "Automations" do
             {
               id: run_id,
               status: "completed",
-              started_at: "2024-01-01T00:00:00.000Z",
-              completed_at: "2024-01-01T00:01:00.000Z",
-              created_at: "2024-01-01T00:00:00.000Z"
+              started_at: "2024-01-01 00:00:00+00",
+              completed_at: "2024-01-01 00:01:00+00",
+              created_at: "2024-01-01 00:00:00+00"
             }
           ]
         }
@@ -243,9 +243,9 @@ RSpec.describe "Automations" do
           object: "automation_run",
           id: run_id,
           status: "completed",
-          started_at: "2024-01-01T00:00:00.000Z",
-          completed_at: "2024-01-01T00:01:00.000Z",
-          created_at: "2024-01-01T00:00:00.000Z",
+          started_at: "2024-01-01 00:00:00+00",
+          completed_at: "2024-01-01 00:01:00+00",
+          created_at: "2024-01-01 00:00:00+00",
           steps: []
         }
         allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)

--- a/spec/broadcasts_spec.rb
+++ b/spec/broadcasts_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "Broadcasts" do
             "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
             "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "status": "draft",
-            "created_at": "2024-11-01T15:13:31.723Z",
+            "created_at": "2024-11-01 15:13:31.723+00",
             "scheduled_at": nil,
             "sent_at": nil
           },
@@ -119,9 +119,9 @@ RSpec.describe "Broadcasts" do
             "id": "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
             "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "status": "sent",
-            "created_at": "2024-12-01T19:32:22.980Z",
-            "scheduled_at": "2024-12-02T19:32:22.980Z",
-            "sent_at": "2024-12-02T19:32:22.980Z"
+            "created_at": "2024-12-01 19:32:22.98+00",
+            "scheduled_at": "2024-12-02 19:32:22.98+00",
+            "sent_at": "2024-12-02 19:32:22.98+00"
           }
         ]
       }
@@ -134,16 +134,16 @@ RSpec.describe "Broadcasts" do
       expect(broadcasts[0][:id]).to eql("49a3999c-0ce1-4ea6-ab68-afcd6dc2e794")
       expect(broadcasts[0][:audience_id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
       expect(broadcasts[0][:status]).to eql("draft")
-      expect(broadcasts[0][:created_at]).to eql("2024-11-01T15:13:31.723Z")
+      expect(broadcasts[0][:created_at]).to eql("2024-11-01 15:13:31.723+00")
       expect(broadcasts[0][:scheduled_at]).to eql(nil)
       expect(broadcasts[0][:sent_at]).to eql(nil)
 
       expect(broadcasts[1][:id]).to eql("559ac32e-9ef5-46fb-82a1-b76b840c0f7b")
       expect(broadcasts[1][:audience_id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
       expect(broadcasts[1][:status]).to eql("sent")
-      expect(broadcasts[1][:created_at]).to eql("2024-12-01T19:32:22.980Z")
-      expect(broadcasts[1][:scheduled_at]).to eql("2024-12-02T19:32:22.980Z")
-      expect(broadcasts[1][:sent_at]).to eql("2024-12-02T19:32:22.980Z")
+      expect(broadcasts[1][:created_at]).to eql("2024-12-01 19:32:22.98+00")
+      expect(broadcasts[1][:scheduled_at]).to eql("2024-12-02 19:32:22.98+00")
+      expect(broadcasts[1][:sent_at]).to eql("2024-12-02 19:32:22.98+00")
     end
   end
 
@@ -168,7 +168,7 @@ RSpec.describe "Broadcasts" do
         "reply_to": nil,
         "preview_text": "Check out our latest announcements",
         "status": "draft",
-        "created_at": "2024-12-01T19:32:22.980Z",
+        "created_at": "2024-12-01 19:32:22.98+00",
         "scheduled_at": nil,
         "sent_at": nil,
         "html": "<p>hello world</p>",
@@ -189,7 +189,7 @@ RSpec.describe "Broadcasts" do
       expect(broadcast[:reply_to]).to eql nil
       expect(broadcast[:preview_text]).to eql "Check out our latest announcements"
       expect(broadcast[:status]).to eql "draft"
-      expect(broadcast[:created_at]).to eql "2024-12-01T19:32:22.980Z"
+      expect(broadcast[:created_at]).to eql "2024-12-01 19:32:22.98+00"
       expect(broadcast[:scheduled_at]).to eql nil
       expect(broadcast[:sent_at]).to eql nil
       expect(broadcast[:html]).to eql "<p>hello world</p>"

--- a/spec/contact_imports_spec.rb
+++ b/spec/contact_imports_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Contacts::Imports" do
         object: "contact_import",
         id: import_id,
         status: "completed",
-        created_at: "2023-10-06T23:47:56.678Z",
+        created_at: "2023-10-06 23:47:56.678+00",
         counts: { "total" => 100, "created" => 80, "updated" => 10, "skipped" => 5, "failed" => 5 }
       }
 
@@ -104,7 +104,7 @@ RSpec.describe "Contacts::Imports" do
             object: "contact_import",
             id: "479e3145-dd38-476b-932c-529ceb705947",
             status: "completed",
-            created_at: "2023-10-06T23:47:56.678Z"
+            created_at: "2023-10-06 23:47:56.678+00"
           }
         ]
       }

--- a/spec/contact_properties_spec.rb
+++ b/spec/contact_properties_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe "ContactProperties" do
         key: "company_name",
         type: "string",
         fallback_value: "Acme Corp",
-        created_at: "2023-04-08T00:11:13.110779+00:00"
+        created_at: "2023-04-08 00:11:13.110779+00"
       }
 
       property_id = "b6d24b8e-af0b-4c3c-be0c-359bbd97381e"
@@ -85,7 +85,7 @@ RSpec.describe "ContactProperties" do
             key: "company_name",
             type: "string",
             fallback_value: "Acme Corp",
-            created_at: "2023-04-08T00:11:13.110779+00:00"
+            created_at: "2023-04-08 00:11:13.110779+00"
           }
         ]
       }

--- a/spec/contacts_segments_spec.rb
+++ b/spec/contacts_segments_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Contacts::Segments" do
           {
             "id": segment_id,
             "name": "Registered Users",
-            "created_at": "2023-10-06T22:59:55.977Z"
+            "created_at": "2023-10-06 22:59:55.977+00"
           }
         ]
       }
@@ -57,7 +57,7 @@ RSpec.describe "Contacts::Segments" do
           {
             "id": segment_id,
             "name": "Registered Users",
-            "created_at": "2023-10-06T22:59:55.977Z"
+            "created_at": "2023-10-06 22:59:55.977+00"
           }
         ],
         "has_more": true

--- a/spec/contacts_spec.rb
+++ b/spec/contacts_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "Contacts" do
         "email": "steve.wozniak@gmail.com",
         "first_name": "Steve",
         "last_name": "Wozniak",
-        "created_at": "2023-10-06T23:47:56.678Z",
+        "created_at": "2023-10-06 23:47:56.678+00",
         "unsubscribed": false
       }
 
@@ -58,7 +58,7 @@ RSpec.describe "Contacts" do
       expect(contact[:last_name]).to eql "Wozniak"
       expect(contact[:email]).to eql "steve.wozniak@gmail.com"
       expect(contact[:unsubscribed]).to be false
-      expect(contact[:created_at]).to eql "2023-10-06T23:47:56.678Z"
+      expect(contact[:created_at]).to eql "2023-10-06 23:47:56.678+00"
     end
 
     it "should retrieve a contact by email" do
@@ -68,7 +68,7 @@ RSpec.describe "Contacts" do
         "email": "steve.wozniak@gmail.com",
         "first_name": "Steve",
         "last_name": "Wozniak",
-        "created_at": "2023-10-06T23:47:56.678Z",
+        "created_at": "2023-10-06 23:47:56.678+00",
         "unsubscribed": false
       }
 
@@ -83,7 +83,7 @@ RSpec.describe "Contacts" do
       expect(contact[:last_name]).to eql "Wozniak"
       expect(contact[:email]).to eql "steve.wozniak@gmail.com"
       expect(contact[:unsubscribed]).to be false
-      expect(contact[:created_at]).to eql "2023-10-06T23:47:56.678Z"
+      expect(contact[:created_at]).to eql "2023-10-06 23:47:56.678+00"
     end
   end
 
@@ -99,7 +99,7 @@ RSpec.describe "Contacts" do
             "email": "steve.wozniak@gmail.com",
             "first_name": "Steve",
             "last_name": "Wozniak",
-            "created_at": "2023-10-06T23:47:56.678Z",
+            "created_at": "2023-10-06 23:47:56.678+00",
             "unsubscribed": false
           }
         ]
@@ -126,7 +126,7 @@ RSpec.describe "Contacts" do
             "email": "steve.wozniak@gmail.com",
             "first_name": "Steve",
             "last_name": "Wozniak",
-            "created_at": "2023-10-06T23:47:56.678Z",
+            "created_at": "2023-10-06 23:47:56.678+00",
             "unsubscribed": false
           }
         ]
@@ -230,7 +230,7 @@ RSpec.describe "Contacts" do
         "email": "global@example.com",
         "first_name": "Global",
         "last_name": "Contact",
-        "created_at": "2023-10-06T23:47:56.678Z",
+        "created_at": "2023-10-06 23:47:56.678+00",
         "unsubscribed": false
       }
 
@@ -255,7 +255,7 @@ RSpec.describe "Contacts" do
             "email": "global@example.com",
             "first_name": "Global",
             "last_name": "Contact",
-            "created_at": "2023-10-06T23:47:56.678Z",
+            "created_at": "2023-10-06 23:47:56.678+00",
             "unsubscribed": false
           }
         ]

--- a/spec/contacts_topics_spec.rb
+++ b/spec/contacts_topics_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe "Contacts::Topics" do
           {
             "id": topic_id,
             "name": "Product Updates",
-            "created_at": "2023-10-06T22:59:55.977Z"
+            "created_at": "2023-10-06 22:59:55.977+00"
           }
         ]
       }
@@ -57,7 +57,7 @@ RSpec.describe "Contacts::Topics" do
           {
             "id": topic_id,
             "name": "Product Updates",
-            "created_at": "2023-10-06T22:59:55.977Z"
+            "created_at": "2023-10-06 22:59:55.977+00"
           }
         ],
         "has_more": true

--- a/spec/domain_claims_spec.rb
+++ b/spec/domain_claims_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe "Domains::Claims" do
         },
         blocked_reason: nil,
         failure_reason: nil,
-        created_at: "2026-06-16T17:12:02.059593+00:00",
-        expires_at: "2026-06-23T17:12:02.059593+00:00"
+        created_at: "2026-06-16 17:12:02.059593+00",
+        expires_at: "2026-06-23 17:12:02.059593+00"
       }
 
       params = { name: "example.com" }
@@ -68,8 +68,8 @@ RSpec.describe "Domains::Claims" do
         region: "us-east-1",
         blocked_reason: "grace_period",
         failure_reason: nil,
-        created_at: "2026-06-16T17:12:02.059593+00:00",
-        expires_at: "2026-06-23T17:12:02.059593+00:00"
+        created_at: "2026-06-16 17:12:02.059593+00",
+        expires_at: "2026-06-23 17:12:02.059593+00"
       }
       allow(resp).to receive(:body).and_return(resp)
       allow(HTTParty).to receive(:send).and_return(resp)

--- a/spec/domains_spec.rb
+++ b/spec/domains_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Domains" do
       resp = {
         "id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
         "name": "example.com",
-        "createdAt": "2023-03-28T17:12:02.059593+00:00",
+        "createdAt": "2023-03-28 17:12:02.059593+00",
         "status": "not_started",
         "records": [
           {
@@ -75,7 +75,7 @@ RSpec.describe "Domains" do
       resp = {
         "id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
         "name": "example.com",
-        "createdAt": "2023-03-28T17:12:02.059593+00:00",
+        "createdAt": "2023-03-28 17:12:02.059593+00",
         "status": "not_started",
         "open_tracking": true,
         "click_tracking": true,
@@ -208,7 +208,7 @@ RSpec.describe "Domains" do
         "id": "d91cd9bd-1176-453e-8fc1-35364d380206",
         "name": "example.com",
         "status": "not_started",
-        "created_at": "2023-04-26T20:21:26.347412+00:00",
+        "created_at": "2023-04-26 20:21:26.347412+00",
         "region": "us-east-1"
       }
       allow(resp).to receive(:body).and_return(resp)
@@ -220,7 +220,7 @@ RSpec.describe "Domains" do
       expect(email[:id]).to eql "d91cd9bd-1176-453e-8fc1-35364d380206"
       expect(email[:name]).to eql "example.com"
       expect(email[:status]).to eql "not_started"
-      expect(email[:created_at]).to eql "2023-04-26T20:21:26.347412+00:00"
+      expect(email[:created_at]).to eql "2023-04-26 20:21:26.347412+00"
       expect(email[:region]).to eql "us-east-1"
     end
 
@@ -230,7 +230,7 @@ RSpec.describe "Domains" do
         "id": "d91cd9bd-1176-453e-8fc1-35364d380206",
         "name": "example.com",
         "status": "not_started",
-        "created_at": "2023-04-26T20:21:26.347412+00:00",
+        "created_at": "2023-04-26 20:21:26.347412+00",
         "region": "us-east-1",
         "open_tracking": true,
         "click_tracking": true,
@@ -255,7 +255,7 @@ RSpec.describe "Domains" do
             "id": "d91cd9bd-1176-453e-8fc1-35364d380206",
             "name": "example.com",
             "status": "not_started",
-            "created_at": "2023-04-26T20:21:26.347412+00:00",
+            "created_at": "2023-04-26 20:21:26.347412+00",
             "region": "us-east-1"
           }
         ]

--- a/spec/emails/attachments_spec.rb
+++ b/spec/emails/attachments_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Emails::Attachments" do
         "content_type" => "application/pdf",
         "content_disposition" => "attachment",
         "download_url" => "https://cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
-        "expires_at" => "2025-10-17T14:29:41.521Z"
+        "expires_at" => "2025-10-17 14:29:41.521+00"
       }
       allow(resp).to receive(:body).and_return(resp)
       allow(HTTParty).to receive(:send).and_return(resp)
@@ -91,7 +91,7 @@ RSpec.describe "Emails::Attachments" do
             "content_type" => "application/pdf",
             "content_disposition" => "attachment",
             "download_url" => "https://cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
-            "expires_at" => "2025-10-17T14:29:41.521Z"
+            "expires_at" => "2025-10-17 14:29:41.521+00"
           }
         ]
       }

--- a/spec/emails/receiving/attachments_spec.rb
+++ b/spec/emails/receiving/attachments_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Emails::Receiving::Attachments" do
         "content_disposition" => "inline",
         "content_id" => "img001",
         "download_url" => "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
-        "expires_at" => "2025-10-17T14:29:41.521Z"
+        "expires_at" => "2025-10-17 14:29:41.521+00"
       }
       allow(resp).to receive(:body).and_return(resp)
       allow(HTTParty).to receive(:send).and_return(resp)
@@ -93,7 +93,7 @@ RSpec.describe "Emails::Receiving::Attachments" do
             "content_disposition" => "inline",
             "content_id" => "img001",
             "download_url" => "https://inbound-cdn.resend.com/4ef9a417-02e9-4d39-ad75-9611e0fcc33c/attachments/2a0c9ce0-3112-4728-976e-47ddcd16a318?some-params=example&signature=sig-123",
-            "expires_at" => "2025-10-17T14:29:41.521Z"
+            "expires_at" => "2025-10-17 14:29:41.521+00"
           }
         ]
       }

--- a/spec/emails/receiving_spec.rb
+++ b/spec/emails/receiving_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Emails::Receiving" do
         "id" => "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
         "to" => ["delivered@resend.dev"],
         "from" => "Acme <onboarding@resend.dev>",
-        "created_at" => "2023-04-03T22:13:42.674981+00:00",
+        "created_at" => "2023-04-03 22:13:42.674981+00",
         "subject" => "Hello World",
         "html" => "Congrats on sending your <strong>first email</strong>!",
         "text" => nil,

--- a/spec/emails_spec.rb
+++ b/spec/emails_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "Emails" do
         "id": "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
         "to": ["james@bond.com"],
         "from": "onboarding@resend.dev",
-        "created_at": "2023-04-03T22:13:42.674981+00:00",
+        "created_at": "2023-04-03 22:13:42.674981+00",
         "subject": "Hello World",
         "html": "Congrats on sending your <strong>first email</strong>!",
         "text": nil,
@@ -217,7 +217,7 @@ RSpec.describe "Emails" do
             "id" => "4ef9a417-02e9-4d39-ad75-9611e0fcc33c",
             "to" => ["james@bond.com"],
             "from" => "onboarding@resend.dev",
-            "created_at" => "2023-04-03T22:13:42.674981+00:00",
+            "created_at" => "2023-04-03 22:13:42.674981+00",
             "subject" => "Hello World",
             "last_event" => "delivered",
             "message_id" => "<111-222-333@email.example.com>"

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -17,8 +17,8 @@ RSpec.describe "Events" do
         id: event_id,
         name: event_name,
         schema: nil,
-        created_at: "2024-01-01T00:00:00.000Z",
-        updated_at: "2024-01-01T00:00:00.000Z"
+        created_at: "2024-01-01 00:00:00+00",
+        updated_at: "2024-01-01 00:00:00+00"
       }
       params = { name: event_name }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
@@ -35,8 +35,8 @@ RSpec.describe "Events" do
         id: event_id,
         name: event_name,
         schema: schema,
-        created_at: "2024-01-01T00:00:00.000Z",
-        updated_at: "2024-01-01T00:00:00.000Z"
+        created_at: "2024-01-01 00:00:00+00",
+        updated_at: "2024-01-01 00:00:00+00"
       }
       params = { name: event_name, schema: schema }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
@@ -64,8 +64,8 @@ RSpec.describe "Events" do
         id: event_id,
         name: event_name,
         schema: nil,
-        created_at: "2024-01-01T00:00:00.000Z",
-        updated_at: "2024-01-01T00:00:00.000Z"
+        created_at: "2024-01-01 00:00:00+00",
+        updated_at: "2024-01-01 00:00:00+00"
       }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Events.get(event_id)
@@ -79,8 +79,8 @@ RSpec.describe "Events" do
         id: event_id,
         name: event_name,
         schema: nil,
-        created_at: "2024-01-01T00:00:00.000Z",
-        updated_at: "2024-01-01T00:00:00.000Z"
+        created_at: "2024-01-01 00:00:00+00",
+        updated_at: "2024-01-01 00:00:00+00"
       }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Events.get(event_name)
@@ -115,8 +115,8 @@ RSpec.describe "Events" do
         id: event_id,
         name: event_name,
         schema: new_schema,
-        created_at: "2024-01-01T00:00:00.000Z",
-        updated_at: "2024-01-02T00:00:00.000Z"
+        created_at: "2024-01-01 00:00:00+00",
+        updated_at: "2024-01-02 00:00:00+00"
       }
       params = { identifier: event_id, schema: new_schema }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
@@ -225,8 +225,8 @@ RSpec.describe "Events" do
             id: event_id,
             name: event_name,
             schema: nil,
-            created_at: "2024-01-01T00:00:00.000Z",
-            updated_at: "2024-01-01T00:00:00.000Z"
+            created_at: "2024-01-01 00:00:00+00",
+            updated_at: "2024-01-01 00:00:00+00"
           }
         ]
       }

--- a/spec/logs_spec.rb
+++ b/spec/logs_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Logs" do
         resp = {
           "object": "log",
           "id": "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
-          "created_at": "2024-11-01T18:10:00.000Z",
+          "created_at": "2024-11-01 18:10:00+00",
           "endpoint": "/emails",
           "method": "POST",
           "response_status": 200,
@@ -34,7 +34,7 @@ RSpec.describe "Logs" do
         resp = {
           "object": "log",
           "id": "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
-          "created_at": "2024-11-01T18:10:00.000Z",
+          "created_at": "2024-11-01 18:10:00+00",
           "endpoint": "/emails",
           "method": "POST",
           "response_status": 200,
@@ -78,7 +78,7 @@ RSpec.describe "Logs" do
           "data": [
             {
               "id": "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
-              "created_at": "2024-11-01T18:10:00.000Z",
+              "created_at": "2024-11-01 18:10:00+00",
               "endpoint": "/emails",
               "method": "POST",
               "response_status": 200,
@@ -86,7 +86,7 @@ RSpec.describe "Logs" do
             },
             {
               "id": "4e5b583e-cd7e-5ee3-bbae-e4e22c650f66",
-              "created_at": "2024-11-01T17:00:00.000Z",
+              "created_at": "2024-11-01 17:00:00+00",
               "endpoint": "/emails",
               "method": "POST",
               "response_status": 422,
@@ -109,7 +109,7 @@ RSpec.describe "Logs" do
           "data": [
             {
               "id": "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
-              "created_at": "2024-11-01T18:10:00.000Z",
+              "created_at": "2024-11-01 18:10:00+00",
               "endpoint": "/emails",
               "method": "POST",
               "response_status": 200,
@@ -137,7 +137,7 @@ RSpec.describe "Logs" do
         resp = {
           "object": "log",
           "id": "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
-          "created_at": "2024-11-01T18:10:00.000Z",
+          "created_at": "2024-11-01 18:10:00+00",
           "endpoint": "/emails",
           "method": "POST",
           "response_status": 200,
@@ -159,7 +159,7 @@ RSpec.describe "Logs" do
           "data": [
             {
               "id": "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
-              "created_at": "2024-11-01T18:10:00.000Z",
+              "created_at": "2024-11-01 18:10:00+00",
               "endpoint": "/emails",
               "method": "POST",
               "response_status": 200,

--- a/spec/oauth_grants_spec.rb
+++ b/spec/oauth_grants_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "OAuth Grants" do
               "client_id": "client_123",
               "scopes": ["emails:send"],
               "resource": nil,
-              "created_at": "2023-04-21T01:31:02.671414+00:00",
+              "created_at": "2023-04-21 01:31:02.671414+00",
               "revoked_at": nil,
               "revoked_reason": nil,
               "client": {

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe "Pagination" do
           {
             "id": "6e3c3d83-05dc-4b51-acfc-fe8972738bd0",
             "name": "test1",
-            "created_at": "2023-04-21T01:31:02.671414+00:00"
+            "created_at": "2023-04-21 01:31:02.671414+00"
           }
         ],
         "has_more": true

--- a/spec/segments_spec.rb
+++ b/spec/segments_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe "Segments" do
         "object": "audience",
         "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
         "name": "Registered Users",
-        "created_at": "2023-10-06T22:59:55.977Z"
+        "created_at": "2023-10-06 22:59:55.977+00"
       }
       allow(resp).to receive(:body).and_return(resp)
       allow(HTTParty).to receive(:send).and_return(resp)
@@ -43,7 +43,7 @@ RSpec.describe "Segments" do
       expect(segment[:object]).to eql "audience"
       expect(segment[:id]).to eql "78261eea-8f8b-4381-83c6-79fa7120f1cf"
       expect(segment[:name]).to eql "Registered Users"
-      expect(segment[:created_at]).to eql "2023-10-06T22:59:55.977Z"
+      expect(segment[:created_at]).to eql "2023-10-06 22:59:55.977+00"
     end
   end
 
@@ -55,7 +55,7 @@ RSpec.describe "Segments" do
           {
             "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
             "name": "Registered Users",
-            "created_at": "2023-10-06T22:59:55.977Z"
+            "created_at": "2023-10-06 22:59:55.977+00"
           }
         ]
       }

--- a/spec/suppressions_spec.rb
+++ b/spec/suppressions_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "Suppressions" do
             "email" => "steve.wozniak@gmail.com",
             "origin" => "bounce",
             "source_id" => "479e3145-dd38-476b-932c-529ceb705947",
-            "created_at" => "2023-10-06T23:47:56.678Z"
+            "created_at" => "2023-10-06 23:47:56.678+00"
           }
         ]
       }
@@ -55,7 +55,7 @@ RSpec.describe "Suppressions" do
       expect(result[:data][0]["id"]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
       expect(result[:data][0]["origin"]).to eql("bounce")
       expect(result[:data][0]["source_id"]).to eql("479e3145-dd38-476b-932c-529ceb705947")
-      expect(result[:data][0]["created_at"]).to eql("2023-10-06T23:47:56.678Z")
+      expect(result[:data][0]["created_at"]).to eql("2023-10-06 23:47:56.678+00")
     end
 
     it "should not expose an object field on list entries" do
@@ -68,7 +68,7 @@ RSpec.describe "Suppressions" do
             "email" => "steve.wozniak@gmail.com",
             "origin" => "bounce",
             "source_id" => "479e3145-dd38-476b-932c-529ceb705947",
-            "created_at" => "2023-10-06T23:47:56.678Z"
+            "created_at" => "2023-10-06 23:47:56.678+00"
           }
         ]
       }
@@ -89,7 +89,7 @@ RSpec.describe "Suppressions" do
             "email" => "steve.wozniak@gmail.com",
             "origin" => "manual",
             "source_id" => nil,
-            "created_at" => "2023-10-06T23:47:56.678Z"
+            "created_at" => "2023-10-06 23:47:56.678+00"
           }
         ]
       }
@@ -122,7 +122,7 @@ RSpec.describe "Suppressions" do
         email: "steve.wozniak@gmail.com",
         origin: "complaint",
         source_id: "479e3145-dd38-476b-932c-529ceb705947",
-        created_at: "2023-10-06T23:47:56.678Z"
+        created_at: "2023-10-06 23:47:56.678+00"
       }
 
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
@@ -130,7 +130,7 @@ RSpec.describe "Suppressions" do
       expect(suppression[:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
       expect(suppression[:email]).to eql("steve.wozniak@gmail.com")
       expect(suppression[:origin]).to eql("complaint")
-      expect(suppression[:created_at]).to eql("2023-10-06T23:47:56.678Z")
+      expect(suppression[:created_at]).to eql("2023-10-06 23:47:56.678+00")
       expect(suppression[:object]).to eql("suppression")
     end
 
@@ -141,7 +141,7 @@ RSpec.describe "Suppressions" do
         email: "steve.wozniak@gmail.com",
         origin: "manual",
         source_id: nil,
-        created_at: "2023-10-06T23:47:56.678Z"
+        created_at: "2023-10-06 23:47:56.678+00"
       }
 
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)

--- a/spec/templates_spec.rb
+++ b/spec/templates_spec.rb
@@ -85,10 +85,10 @@ RSpec.describe "Templates" do
         "id": "34a080c9-b17d-4187-ad80-5af20266e535",
         "alias": "reset-password",
         "name": "reset-password",
-        "created_at": "2023-10-06T23:47:56.678Z",
-        "updated_at": "2023-10-06T23:47:56.678Z",
+        "created_at": "2023-10-06 23:47:56.678+00",
+        "updated_at": "2023-10-06 23:47:56.678+00",
         "status": "published",
-        "published_at": "2023-10-06T23:47:56.678Z",
+        "published_at": "2023-10-06 23:47:56.678+00",
         "from": "John Doe <john.doe@example.com>",
         "subject": "Hello, world!",
         "reply_to": nil,
@@ -100,8 +100,8 @@ RSpec.describe "Templates" do
             "key" => "user_name",
             "type" => "string",
             "fallback_value" => "John Doe",
-            "created_at" => "2023-10-06T23:47:56.678Z",
-            "updated_at" => "2023-10-06T23:47:56.678Z"
+            "created_at" => "2023-10-06 23:47:56.678+00",
+            "updated_at" => "2023-10-06 23:47:56.678+00"
           }
         ]
       }
@@ -130,10 +130,10 @@ RSpec.describe "Templates" do
         "id": "34a080c9-b17d-4187-ad80-5af20266e535",
         "alias": "reset-password",
         "name": "reset-password",
-        "created_at": "2023-10-06T23:47:56.678Z",
-        "updated_at": "2023-10-06T23:47:56.678Z",
+        "created_at": "2023-10-06 23:47:56.678+00",
+        "updated_at": "2023-10-06 23:47:56.678+00",
         "status": "published",
-        "published_at": "2023-10-06T23:47:56.678Z",
+        "published_at": "2023-10-06 23:47:56.678+00",
         "from": "John Doe <john.doe@example.com>",
         "subject": "Hello, world!",
         "reply_to": nil,
@@ -263,17 +263,17 @@ RSpec.describe "Templates" do
             "name": "reset-password",
             "status": "draft",
             "published_at": nil,
-            "created_at": "2023-10-06T23:47:56.678Z",
-            "updated_at": "2023-10-06T23:47:56.678Z",
+            "created_at": "2023-10-06 23:47:56.678+00",
+            "updated_at": "2023-10-06 23:47:56.678+00",
             "alias": "reset-password"
           },
           {
             "id": "b7f9c2e1-1234-4abc-9def-567890abcdef",
             "name": "welcome-message",
             "status": "published",
-            "published_at": "2023-10-06T23:47:56.678Z",
-            "created_at": "2023-10-06T23:47:56.678Z",
-            "updated_at": "2023-10-06T23:47:56.678Z",
+            "published_at": "2023-10-06 23:47:56.678+00",
+            "created_at": "2023-10-06 23:47:56.678+00",
+            "updated_at": "2023-10-06 23:47:56.678+00",
             "alias": "welcome-message"
           }
         ],

--- a/spec/topics_spec.rb
+++ b/spec/topics_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Topics" do
         "name": "Weekly Newsletter",
         "description": "Weekly newsletter for our subscribers",
         "default_subscription": "opt_in",
-        "created_at": "2023-04-08T00:11:13.110779+00:00"
+        "created_at": "2023-04-08 00:11:13.110779+00"
       }
 
       allow(resp).to receive(:body).and_return(resp)
@@ -42,7 +42,7 @@ RSpec.describe "Topics" do
       expect(topic[:name]).to eql "Weekly Newsletter"
       expect(topic[:description]).to eql "Weekly newsletter for our subscribers"
       expect(topic[:default_subscription]).to eql "opt_in"
-      expect(topic[:created_at]).to eql "2023-04-08T00:11:13.110779+00:00"
+      expect(topic[:created_at]).to eql "2023-04-08 00:11:13.110779+00"
     end
   end
 
@@ -72,14 +72,14 @@ RSpec.describe "Topics" do
             "name": "Weekly Newsletter",
             "description": "Weekly newsletter for our subscribers",
             "default_subscription": "opt_in",
-            "created_at": "2023-04-08T00:11:13.110779+00:00"
+            "created_at": "2023-04-08 00:11:13.110779+00"
           },
           {
             "id": "c7e35c9f-1fc2-5db5-cf1d-46af8e4c2f91",
             "name": "Monthly Updates",
             "description": "Monthly product updates",
             "default_subscription": "opt_out",
-            "created_at": "2023-04-09T10:15:20.220890+00:00"
+            "created_at": "2023-04-09 10:15:20.22089+00"
           }
         ]
       }
@@ -93,13 +93,13 @@ RSpec.describe "Topics" do
       expect(topics[0][:name]).to eql("Weekly Newsletter")
       expect(topics[0][:description]).to eql("Weekly newsletter for our subscribers")
       expect(topics[0][:default_subscription]).to eql("opt_in")
-      expect(topics[0][:created_at]).to eql("2023-04-08T00:11:13.110779+00:00")
+      expect(topics[0][:created_at]).to eql("2023-04-08 00:11:13.110779+00")
 
       expect(topics[1][:id]).to eql("c7e35c9f-1fc2-5db5-cf1d-46af8e4c2f91")
       expect(topics[1][:name]).to eql("Monthly Updates")
       expect(topics[1][:description]).to eql("Monthly product updates")
       expect(topics[1][:default_subscription]).to eql("opt_out")
-      expect(topics[1][:created_at]).to eql("2023-04-09T10:15:20.220890+00:00")
+      expect(topics[1][:created_at]).to eql("2023-04-09 10:15:20.22089+00")
     end
   end
 

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe "Webhooks" do
       resp = {
         "object": "webhook",
         "id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
-        "created_at": "2023-08-22T15:28:00.000Z",
+        "created_at": "2023-08-22 15:28:00+00",
         "status": "enabled",
         "endpoint": "https://webhook.example.com/handler",
         "events": ["email.sent", "email.received"],
@@ -64,7 +64,7 @@ RSpec.describe "Webhooks" do
       expect(webhook[:endpoint]).to eql("https://webhook.example.com/handler")
       expect(webhook[:events]).to eql(["email.sent", "email.received"])
       expect(webhook[:signing_secret]).to eql("whsec_xxxxxxxxxx")
-      expect(webhook[:created_at]).to eql("2023-08-22T15:28:00.000Z")
+      expect(webhook[:created_at]).to eql("2023-08-22 15:28:00+00")
     end
 
     it "should handle webhook not found" do
@@ -125,14 +125,14 @@ RSpec.describe "Webhooks" do
         "data": [
           {
             "id": "7ab123cd-ef45-6789-abcd-ef0123456789",
-            "created_at": "2023-09-10T10:15:30.000Z",
+            "created_at": "2023-09-10 10:15:30+00",
             "status": "disabled",
             "endpoint": "https://first-webhook.example.com/handler",
             "events": ["email.delivered", "email.bounced"]
           },
           {
             "id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
-            "created_at": "2023-08-22T15:28:00.000Z",
+            "created_at": "2023-08-22 15:28:00+00",
             "status": "enabled",
             "endpoint": "https://second-webhook.example.com/receive",
             "events": ["email.received"]
@@ -151,13 +151,13 @@ RSpec.describe "Webhooks" do
       expect(webhooks[:data][0][:status]).to eql("disabled")
       expect(webhooks[:data][0][:endpoint]).to eql("https://first-webhook.example.com/handler")
       expect(webhooks[:data][0][:events]).to eql(["email.delivered", "email.bounced"])
-      expect(webhooks[:data][0][:created_at]).to eql("2023-09-10T10:15:30.000Z")
+      expect(webhooks[:data][0][:created_at]).to eql("2023-09-10 10:15:30+00")
 
       expect(webhooks[:data][1][:id]).to eql("4dd369bc-aa82-4ff3-97de-514ae3000ee0")
       expect(webhooks[:data][1][:status]).to eql("enabled")
       expect(webhooks[:data][1][:endpoint]).to eql("https://second-webhook.example.com/receive")
       expect(webhooks[:data][1][:events]).to eql(["email.received"])
-      expect(webhooks[:data][1][:created_at]).to eql("2023-08-22T15:28:00.000Z")
+      expect(webhooks[:data][1][:created_at]).to eql("2023-08-22 15:28:00+00")
     end
 
     it "should list webhooks with pagination" do
@@ -167,7 +167,7 @@ RSpec.describe "Webhooks" do
         "data": [
           {
             "id": "7ab123cd-ef45-6789-abcd-ef0123456789",
-            "created_at": "2023-09-10T10:15:30.000Z",
+            "created_at": "2023-09-10 10:15:30+00",
             "status": "enabled",
             "endpoint": "https://webhook.example.com/handler",
             "events": ["email.sent"]


### PR DESCRIPTION
## What

The API returns timestamps in Postgres text format: `YYYY-MM-DD HH:MM:SS[.ffffff]+00` (for example `2023-10-06 23:47:56.678+00`). Spec fixtures and their assertions showed ISO 8601 for response fields. This PR makes them match the real API output.

- Convert 120 response-fixture timestamps and paired assertions in 24 spec files.
- `spec/emails/receiving_spec.rb:113` already used the correct format; the rest of the repo now matches it.

## What stays ISO 8601 on purpose

- `scheduled_at` as a request param (`spec/emails_spec.rb`, `examples/schedule_email.rb`). The API accepts ISO there.
- The webhook event payload strings in the signature verification specs. Webhooks emit ISO, and these strings feed the HMAC computation.
- `revoked_at` in the revoke OAuth grant response. That endpoint returns ISO.

## Why

The SDK never parses these values, so there are no runtime changes. But wrong fixtures propagate: new endpoints copy the pattern, and users who read the specs get the wrong contract.

## Verification

- `bundle exec rake spec`: 336 examples, 0 failures.
- `bundle exec rubocop`: no offenses.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated spec fixtures and assertions to use the API’s Postgres timestamp format so tests match real responses. No runtime changes.

- **Refactors**
  - Converted 120 timestamps across 24 spec files from ISO 8601 to Postgres text format (`YYYY-MM-DD HH:MM:SS[.ffffff]+00`).
  - Kept ISO 8601 where the API uses it: `scheduled_at` request param, webhook event payload strings in signature specs, and `revoked_at` in the revoke OAuth grant response.

<sup>Written for commit 037b2c4ea8d52852e6271c9e97636b754ab913f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

