### PR TITLE
feat: add Broadcasts.cancel method

### DIFF
--- a/lib/resend/broadcasts.rb
+++ b/lib/resend/broadcasts.rb
@@ -41,6 +41,11 @@ module Resend
         Resend::Request.new(path, {}, "get").perform
       end
 
+      def cancel(broadcast_id = "")
+        path = "broadcasts/#{broadcast_id}/cancel"
+        Resend::Request.new(path, {}, "post").perform
+      end
+
       # https://resend.com/docs/api-reference/broadcasts/delete-broadcast
       def remove(broadcast_id = "")
         path = "broadcasts/#{broadcast_id}"

--- a/spec/broadcasts_spec.rb
+++ b/spec/broadcasts_spec.rb
@@ -147,6 +147,20 @@ RSpec.describe "Broadcasts" do
     end
   end
 
+  describe "cancel" do
+    it "should cancel broadcast" do
+      resp = {
+        "object": "broadcast",
+        "id": "559ac32e-9ef5-46fb-82a1-b76b840c0f7b"
+      }
+      allow(resp).to receive(:body).and_return(resp)
+      allow(HTTParty).to receive(:send).and_return(resp)
+
+      broadcast = Resend::Broadcasts.cancel(resp[:id])
+      expect(broadcast[:id]).to eql "559ac32e-9ef5-46fb-82a1-b76b840c0f7b"
+    end
+  end
+
   describe "remove" do
     it "should remove broadcast" do
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return("")


### PR DESCRIPTION
## Summary
- Adds `Resend::Broadcasts.cancel(broadcast_id)`, calling `POST /broadcasts/:id/cancel` to cancel a queued or scheduled broadcast.
- Mirrors `Emails.cancel`'s shape (no params, id-only).

Part of the broadcast cancel rollout: resend/resend-monorepo#8126, resend/resend-openapi#85, resend/resend-node#1059, resend/resend-docs#1722, resend/resend-go#144, resend/resend-java#122, resend/resend-php#135, resend/resend-python#250.

## Test plan
- [x] `ruby -c` on touched files — syntax OK
- [ ] Could not run the RSpec suite locally (gemspec requires Ruby >= 3.2; this machine only has system Ruby 2.6.10, no version manager available) — relying on CI to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Resend::Broadcasts.cancel(broadcast_id)` to cancel a queued or scheduled broadcast via POST `/broadcasts/:id/cancel`. Mirrors `Emails.cancel` (id-only, no params).

<sup>Written for commit 5faef891e7e0a8e2a994aaac3bcb1976fe37e65d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

