### PR TITLE
chore: use String keys for nested hashes in spec fixtures

### DIFF
--- a/spec/api_keys_spec.rb
+++ b/spec/api_keys_spec.rb
@@ -43,23 +43,23 @@ RSpec.describe "API Keys" do
         resp = {
           "data": [
             {
-              "id":"6e3c3d83-05dc-4b51-acfc-fe8972738bd0",
-              "name":"test1",
-              "created_at":"2023-04-21 01:31:02.671414+00",
-              "last_used_at":"2023-04-22 10:00:00+00"
+              "id" => "6e3c3d83-05dc-4b51-acfc-fe8972738bd0",
+              "name" => "test1",
+              "created_at" => "2023-04-21 01:31:02.671414+00",
+              "last_used_at" => "2023-04-22 10:00:00+00"
             },
             {
-              "id":"7f4d4e94-16ed-5c62-bdfd-gf9083849ce1",
-              "name":"test2",
-              "created_at":"2023-04-21 01:31:02.671414+00",
-              "last_used_at":nil
+              "id" => "7f4d4e94-16ed-5c62-bdfd-gf9083849ce1",
+              "name" => "test2",
+              "created_at" => "2023-04-21 01:31:02.671414+00",
+              "last_used_at" => nil
             }
           ]
         }
         allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
         expect(Resend::ApiKeys.list[:data].length).to eql(2)
-        expect(Resend::ApiKeys.list[:data].first[:last_used_at]).to eql("2023-04-22 10:00:00+00")
-        expect(Resend::ApiKeys.list[:data].last[:last_used_at]).to be_nil
+        expect(Resend::ApiKeys.list[:data].first["last_used_at"]).to eql("2023-04-22 10:00:00+00")
+        expect(Resend::ApiKeys.list[:data].last["last_used_at"]).to be_nil
       end
     end
 
@@ -113,23 +113,23 @@ RSpec.describe "API Keys" do
         resp = {
           "data": [
             {
-              "id":"6e3c3d83-05dc-4b51-acfc-fe8972738bd0",
-              "name":"test1",
-              "created_at":"2023-04-21 01:31:02.671414+00",
-              "last_used_at":"2023-04-22 10:00:00+00"
+              "id" => "6e3c3d83-05dc-4b51-acfc-fe8972738bd0",
+              "name" => "test1",
+              "created_at" => "2023-04-21 01:31:02.671414+00",
+              "last_used_at" => "2023-04-22 10:00:00+00"
             },
             {
-              "id":"7f4d4e94-16ed-5c62-bdfd-gf9083849ce1",
-              "name":"test2",
-              "created_at":"2023-04-21 01:31:02.671414+00",
-              "last_used_at":nil
+              "id" => "7f4d4e94-16ed-5c62-bdfd-gf9083849ce1",
+              "name" => "test2",
+              "created_at" => "2023-04-21 01:31:02.671414+00",
+              "last_used_at" => nil
             }
           ]
         }
         allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
         expect(Resend::ApiKeys.list[:data].length).to eql(2)
-        expect(Resend::ApiKeys.list[:data].first[:last_used_at]).to eql("2023-04-22 10:00:00+00")
-        expect(Resend::ApiKeys.list[:data].last[:last_used_at]).to be_nil
+        expect(Resend::ApiKeys.list[:data].first["last_used_at"]).to eql("2023-04-22 10:00:00+00")
+        expect(Resend::ApiKeys.list[:data].last["last_used_at"]).to be_nil
       end
     end
 

--- a/spec/audiences_spec.rb
+++ b/spec/audiences_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe "Audiences" do
         "object": "list",
         "data": [
           {
-            "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-            "name": "Registered Users",
-            "created_at": "2023-10-06 22:59:55.977+00"
+            "id" => "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "name" => "Registered Users",
+            "created_at" => "2023-10-06 22:59:55.977+00"
           }
         ]
       }
@@ -64,8 +64,8 @@ RSpec.describe "Audiences" do
       expect(audiences[:object]).to eql "list"
       expect(audiences[:data].empty?).to be false
       expect(audiences[:data].length).to eql(1)
-      expect(audiences[:data].first[:id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
-      expect(audiences[:data].first[:name]).to eql("Registered Users")
+      expect(audiences[:data].first["id"]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
+      expect(audiences[:data].first["name"]).to eql("Registered Users")
     end
   end
 

--- a/spec/automations_spec.rb
+++ b/spec/automations_spec.rb
@@ -55,8 +55,11 @@ RSpec.describe "Automations" do
         status: "enabled",
         created_at: "2024-01-01 00:00:00+00",
         updated_at: "2024-01-01 00:00:00+00",
-        steps: steps,
-        connections: connections
+        steps: [
+          { "key" => "trigger", "type" => "trigger", "config" => { "event_name" => "user.created" } },
+          { "key" => "send_welcome", "type" => "send_email", "config" => { "template" => { "id" => "tpl_xxx" } } }
+        ],
+        connections: [{ "from" => "trigger", "to" => "send_welcome", "type" => "default" }]
       }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Automations.get(automation_id)
@@ -155,7 +158,7 @@ RSpec.describe "Automations" do
         object: "list",
         has_more: false,
         data: [
-          { id: automation_id, name: "Welcome Automation", status: "enabled", created_at: "2024-01-01 00:00:00+00" }
+          { "id" => automation_id, "name" => "Welcome Automation", "status" => "enabled", "created_at" => "2024-01-01 00:00:00+00" }
         ]
       }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
@@ -163,18 +166,18 @@ RSpec.describe "Automations" do
       expect(result[:object]).to eql("list")
       expect(result[:data].length).to eql(1)
       expect(result[:has_more]).to eql(false)
-      expect(result[:data].first[:id]).to eql(automation_id)
+      expect(result[:data].first["id"]).to eql(automation_id)
     end
 
     it "should list automations with status filter" do
-      resp = { object: "list", has_more: false, data: [{ id: automation_id, status: "enabled" }] }
+      resp = { object: "list", has_more: false, data: [{ "id" => automation_id, "status" => "enabled" }] }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Automations.list({ status: "enabled" })
-      expect(result[:data].first[:status]).to eql("enabled")
+      expect(result[:data].first["status"]).to eql("enabled")
     end
 
     it "should list automations with pagination params" do
-      resp = { object: "list", has_more: true, data: [{ id: automation_id }] }
+      resp = { object: "list", has_more: true, data: [{ "id" => automation_id }] }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Automations.list({ limit: 1 })
       expect(result[:has_more]).to eql(true)
@@ -203,11 +206,11 @@ RSpec.describe "Automations" do
           has_more: false,
           data: [
             {
-              id: run_id,
-              status: "completed",
-              started_at: "2024-01-01 00:00:00+00",
-              completed_at: "2024-01-01 00:01:00+00",
-              created_at: "2024-01-01 00:00:00+00"
+              "id" => run_id,
+              "status" => "completed",
+              "started_at" => "2024-01-01 00:00:00+00",
+              "completed_at" => "2024-01-01 00:01:00+00",
+              "created_at" => "2024-01-01 00:00:00+00"
             }
           ]
         }
@@ -215,7 +218,7 @@ RSpec.describe "Automations" do
         result = Resend::Automations::Runs.list(automation_id)
         expect(result[:object]).to eql("list")
         expect(result[:data].length).to eql(1)
-        expect(result[:data].first[:id]).to eql(run_id)
+        expect(result[:data].first["id"]).to eql(run_id)
         expect(result[:has_more]).to eql(false)
       end
 
@@ -230,7 +233,7 @@ RSpec.describe "Automations" do
       end
 
       it "should list runs with pagination params" do
-        resp = { object: "list", has_more: true, data: [{ id: run_id }] }
+        resp = { object: "list", has_more: true, data: [{ "id" => run_id }] }
         allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
         result = Resend::Automations::Runs.list(automation_id, { limit: 1 })
         expect(result[:has_more]).to eql(true)

--- a/spec/batch_spec.rb
+++ b/spec/batch_spec.rb
@@ -11,10 +11,10 @@ RSpec.describe "Batch" do
       resp = {
         "data": [
           {
-            "id": "ae2014de-c168-4c61-8267-70d2662a1ce1"
+            "id" => "ae2014de-c168-4c61-8267-70d2662a1ce1"
           },
           {
-            "id": "faccb7a5-8a28-4e9a-ac64-8da1cc3bc1cb"
+            "id" => "faccb7a5-8a28-4e9a-ac64-8da1cc3bc1cb"
           }
         ]
       }
@@ -142,8 +142,8 @@ RSpec.describe "Batch" do
     it "does not send the x-batch-validation header when :batch_validation is not provided" do
       resp = {
         "data": [
-          { "id": "ae2014de-c168-4c61-8267-70d2662a1ce1" },
-          { "id": "faccb7a5-8a28-4e9a-ac64-8da1cc3bc1cb" }
+          { "id" => "ae2014de-c168-4c61-8267-70d2662a1ce1" },
+          { "id" => "faccb7a5-8a28-4e9a-ac64-8da1cc3bc1cb" }
         ]
       }
 
@@ -170,10 +170,10 @@ RSpec.describe "Batch" do
     it "sends the x-batch-validation header when :batch_validation is set to permissive" do
       resp = {
         "data": [
-          { "id": "ae2014de-c168-4c61-8267-70d2662a1ce1" }
+          { "id" => "ae2014de-c168-4c61-8267-70d2662a1ce1" }
         ],
         "errors": [
-          { "index": 1, "message": "Invalid email address" }
+          { "index" => 1, "message" => "Invalid email address" }
         ]
       }
 
@@ -201,8 +201,8 @@ RSpec.describe "Batch" do
     it "sends the x-batch-validation header when :batch_validation is set to strict" do
       resp = {
         "data": [
-          { "id": "ae2014de-c168-4c61-8267-70d2662a1ce1" },
-          { "id": "faccb7a5-8a28-4e9a-ac64-8da1cc3bc1cb" }
+          { "id" => "ae2014de-c168-4c61-8267-70d2662a1ce1" },
+          { "id" => "faccb7a5-8a28-4e9a-ac64-8da1cc3bc1cb" }
         ]
       }
 
@@ -230,12 +230,12 @@ RSpec.describe "Batch" do
     it "handles response with errors array in permissive mode" do
       resp = {
         "data": [
-          { "id": "ae2014de-c168-4c61-8267-70d2662a1ce1" }
+          { "id" => "ae2014de-c168-4c61-8267-70d2662a1ce1" }
         ],
         "errors": [
           {
-            "index": 1,
-            "message": "The 'to' field must be a valid email address"
+            "index" => 1,
+            "message" => "The 'to' field must be a valid email address"
           }
         ]
       }
@@ -262,15 +262,15 @@ RSpec.describe "Batch" do
       expect(result[:data].length).to eq 1
       expect(result[:errors]).not_to be_nil
       expect(result[:errors].length).to eq 1
-      expect(result[:errors][0][:index]).to eq 1
-      expect(result[:errors][0][:message]).to include("valid email address")
+      expect(result[:errors][0]["index"]).to eq 1
+      expect(result[:errors][0]["message"]).to include("valid email address")
     end
 
     it "sends batch email with templates" do
       resp = {
         "data": [
-          { "id": "ae2014de-c168-4c61-8267-70d2662a1ce1" },
-          { "id": "faccb7a5-8a28-4e9a-ac64-8da1cc3bc1cb" }
+          { "id" => "ae2014de-c168-4c61-8267-70d2662a1ce1" },
+          { "id" => "faccb7a5-8a28-4e9a-ac64-8da1cc3bc1cb" }
         ]
       }
 

--- a/spec/broadcasts_spec.rb
+++ b/spec/broadcasts_spec.rb
@@ -108,20 +108,20 @@ RSpec.describe "Broadcasts" do
         "object": "list",
         "data": [
           {
-            "id": "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
-            "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-            "status": "draft",
-            "created_at": "2024-11-01 15:13:31.723+00",
-            "scheduled_at": nil,
-            "sent_at": nil
+            "id" => "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794",
+            "audience_id" => "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "status" => "draft",
+            "created_at" => "2024-11-01 15:13:31.723+00",
+            "scheduled_at" => nil,
+            "sent_at" => nil
           },
           {
-            "id": "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
-            "audience_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-            "status": "sent",
-            "created_at": "2024-12-01 19:32:22.98+00",
-            "scheduled_at": "2024-12-02 19:32:22.98+00",
-            "sent_at": "2024-12-02 19:32:22.98+00"
+            "id" => "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
+            "audience_id" => "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "status" => "sent",
+            "created_at" => "2024-12-01 19:32:22.98+00",
+            "scheduled_at" => "2024-12-02 19:32:22.98+00",
+            "sent_at" => "2024-12-02 19:32:22.98+00"
           }
         ]
       }
@@ -131,19 +131,19 @@ RSpec.describe "Broadcasts" do
 
       expect(broadcasts.length).to eql(2)
 
-      expect(broadcasts[0][:id]).to eql("49a3999c-0ce1-4ea6-ab68-afcd6dc2e794")
-      expect(broadcasts[0][:audience_id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
-      expect(broadcasts[0][:status]).to eql("draft")
-      expect(broadcasts[0][:created_at]).to eql("2024-11-01 15:13:31.723+00")
-      expect(broadcasts[0][:scheduled_at]).to eql(nil)
-      expect(broadcasts[0][:sent_at]).to eql(nil)
+      expect(broadcasts[0]["id"]).to eql("49a3999c-0ce1-4ea6-ab68-afcd6dc2e794")
+      expect(broadcasts[0]["audience_id"]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
+      expect(broadcasts[0]["status"]).to eql("draft")
+      expect(broadcasts[0]["created_at"]).to eql("2024-11-01 15:13:31.723+00")
+      expect(broadcasts[0]["scheduled_at"]).to eql(nil)
+      expect(broadcasts[0]["sent_at"]).to eql(nil)
 
-      expect(broadcasts[1][:id]).to eql("559ac32e-9ef5-46fb-82a1-b76b840c0f7b")
-      expect(broadcasts[1][:audience_id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
-      expect(broadcasts[1][:status]).to eql("sent")
-      expect(broadcasts[1][:created_at]).to eql("2024-12-01 19:32:22.98+00")
-      expect(broadcasts[1][:scheduled_at]).to eql("2024-12-02 19:32:22.98+00")
-      expect(broadcasts[1][:sent_at]).to eql("2024-12-02 19:32:22.98+00")
+      expect(broadcasts[1]["id"]).to eql("559ac32e-9ef5-46fb-82a1-b76b840c0f7b")
+      expect(broadcasts[1]["audience_id"]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
+      expect(broadcasts[1]["status"]).to eql("sent")
+      expect(broadcasts[1]["created_at"]).to eql("2024-12-01 19:32:22.98+00")
+      expect(broadcasts[1]["scheduled_at"]).to eql("2024-12-02 19:32:22.98+00")
+      expect(broadcasts[1]["sent_at"]).to eql("2024-12-02 19:32:22.98+00")
     end
   end
 

--- a/spec/contact_imports_spec.rb
+++ b/spec/contact_imports_spec.rb
@@ -101,10 +101,10 @@ RSpec.describe "Contacts::Imports" do
         has_more: false,
         data: [
           {
-            object: "contact_import",
-            id: "479e3145-dd38-476b-932c-529ceb705947",
-            status: "completed",
-            created_at: "2023-10-06 23:47:56.678+00"
+            "object" => "contact_import",
+            "id" => "479e3145-dd38-476b-932c-529ceb705947",
+            "status" => "completed",
+            "created_at" => "2023-10-06 23:47:56.678+00"
           }
         ]
       }
@@ -113,7 +113,7 @@ RSpec.describe "Contacts::Imports" do
       result = Resend::Contacts::Imports.list
       expect(result[:object]).to eql("list")
       expect(result[:data].length).to eql(1)
-      expect(result[:data][0][:id]).to eql("479e3145-dd38-476b-932c-529ceb705947")
+      expect(result[:data][0]["id"]).to eql("479e3145-dd38-476b-932c-529ceb705947")
     end
 
     it "should list contact imports with status filter" do

--- a/spec/contact_properties_spec.rb
+++ b/spec/contact_properties_spec.rb
@@ -81,11 +81,11 @@ RSpec.describe "ContactProperties" do
         has_more: false,
         data: [
           {
-            id: "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-            key: "company_name",
-            type: "string",
-            fallback_value: "Acme Corp",
-            created_at: "2023-04-08 00:11:13.110779+00"
+            "id" => "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            "key" => "company_name",
+            "type" => "string",
+            "fallback_value" => "Acme Corp",
+            "created_at" => "2023-04-08 00:11:13.110779+00"
           }
         ]
       }
@@ -97,7 +97,7 @@ RSpec.describe "ContactProperties" do
       expect(properties[:object]).to eql("list")
       expect(properties[:has_more]).to eql(false)
       expect(properties[:data]).to be_an(Array)
-      expect(properties[:data].first[:id]).to eql("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+      expect(properties[:data].first["id"]).to eql("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
     end
 
     it "should list contact properties with pagination" do

--- a/spec/contacts/topics_spec.rb
+++ b/spec/contacts/topics_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe "Contacts::Topics" do
         has_more: false,
         data: [
           {
-            id: "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-            name: "Product Updates",
-            description: "New features, and latest announcements.",
-            subscription: "opt_in"
+            "id" => "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            "name" => "Product Updates",
+            "description" => "New features, and latest announcements.",
+            "subscription" => "opt_in"
           }
         ]
       }
@@ -30,8 +30,8 @@ RSpec.describe "Contacts::Topics" do
       expect(topics[:object]).to eql("list")
       expect(topics[:has_more]).to eql(false)
       expect(topics[:data]).to be_an(Array)
-      expect(topics[:data].first[:id]).to eql("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
-      expect(topics[:data].first[:subscription]).to eql("opt_in")
+      expect(topics[:data].first["id"]).to eql("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+      expect(topics[:data].first["subscription"]).to eql("opt_in")
     end
 
     it "should list topics by contact email" do
@@ -40,10 +40,10 @@ RSpec.describe "Contacts::Topics" do
         has_more: false,
         data: [
           {
-            id: "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-            name: "Product Updates",
-            description: "New features, and latest announcements.",
-            subscription: "opt_in"
+            "id" => "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            "name" => "Product Updates",
+            "description" => "New features, and latest announcements.",
+            "subscription" => "opt_in"
           }
         ]
       }

--- a/spec/contacts_segments_spec.rb
+++ b/spec/contacts_segments_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe "Contacts::Segments" do
         "object": "list",
         "data": [
           {
-            "id": segment_id,
-            "name": "Registered Users",
-            "created_at": "2023-10-06 22:59:55.977+00"
+            "id" => segment_id,
+            "name" => "Registered Users",
+            "created_at" => "2023-10-06 22:59:55.977+00"
           }
         ]
       }
@@ -28,8 +28,8 @@ RSpec.describe "Contacts::Segments" do
       segments = Resend::Contacts::Segments.list(contact_id: contact_id)
       expect(segments[:object]).to eql "list"
       expect(segments[:data].length).to eql 1
-      expect(segments[:data][0][:id]).to eql segment_id
-      expect(segments[:data][0][:name]).to eql "Registered Users"
+      expect(segments[:data][0]["id"]).to eql segment_id
+      expect(segments[:data][0]["name"]).to eql "Registered Users"
     end
 
     it "should list segments for a contact using email" do
@@ -55,9 +55,9 @@ RSpec.describe "Contacts::Segments" do
         "object": "list",
         "data": [
           {
-            "id": segment_id,
-            "name": "Registered Users",
-            "created_at": "2023-10-06 22:59:55.977+00"
+            "id" => segment_id,
+            "name" => "Registered Users",
+            "created_at" => "2023-10-06 22:59:55.977+00"
           }
         ],
         "has_more": true

--- a/spec/contacts_spec.rb
+++ b/spec/contacts_spec.rb
@@ -95,12 +95,12 @@ RSpec.describe "Contacts" do
         "object": "list",
         "data": [
           {
-            "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            "email": "steve.wozniak@gmail.com",
-            "first_name": "Steve",
-            "last_name": "Wozniak",
-            "created_at": "2023-10-06 23:47:56.678+00",
-            "unsubscribed": false
+            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "steve.wozniak@gmail.com",
+            "first_name" => "Steve",
+            "last_name" => "Wozniak",
+            "created_at" => "2023-10-06 23:47:56.678+00",
+            "unsubscribed" => false
           }
         ]
       }
@@ -109,11 +109,11 @@ RSpec.describe "Contacts" do
       contacts = Resend::Contacts.list(audience_id: audience_id)
       expect(contacts[:object]).to eql "list"
       expect(contacts[:data].length).to eql 1
-      expect(contacts[:data][0][:id]).to eql "e169aa45-1ecf-4183-9955-b1499d5701d3"
-      expect(contacts[:data][0][:first_name]).to eql "Steve"
-      expect(contacts[:data][0][:last_name]).to eql "Wozniak"
-      expect(contacts[:data][0][:email]).to eql "steve.wozniak@gmail.com"
-      expect(contacts[:data][0][:unsubscribed]).to be false
+      expect(contacts[:data][0]["id"]).to eql "e169aa45-1ecf-4183-9955-b1499d5701d3"
+      expect(contacts[:data][0]["first_name"]).to eql "Steve"
+      expect(contacts[:data][0]["last_name"]).to eql "Wozniak"
+      expect(contacts[:data][0]["email"]).to eql "steve.wozniak@gmail.com"
+      expect(contacts[:data][0]["unsubscribed"]).to be false
     end
 
     it "should list contacts with pagination" do
@@ -122,12 +122,12 @@ RSpec.describe "Contacts" do
         "object": "list",
         "data": [
           {
-            "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            "email": "steve.wozniak@gmail.com",
-            "first_name": "Steve",
-            "last_name": "Wozniak",
-            "created_at": "2023-10-06 23:47:56.678+00",
-            "unsubscribed": false
+            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "steve.wozniak@gmail.com",
+            "first_name" => "Steve",
+            "last_name" => "Wozniak",
+            "created_at" => "2023-10-06 23:47:56.678+00",
+            "unsubscribed" => false
           }
         ]
       }
@@ -136,11 +136,11 @@ RSpec.describe "Contacts" do
       contacts = Resend::Contacts.list(audience_id: audience_id, limit: 10)
       expect(contacts[:object]).to eql "list"
       expect(contacts[:data].length).to eql 1
-      expect(contacts[:data][0][:id]).to eql "e169aa45-1ecf-4183-9955-b1499d5701d3"
-      expect(contacts[:data][0][:first_name]).to eql "Steve"
-      expect(contacts[:data][0][:last_name]).to eql "Wozniak"
-      expect(contacts[:data][0][:email]).to eql "steve.wozniak@gmail.com"
-      expect(contacts[:data][0][:unsubscribed]).to be false
+      expect(contacts[:data][0]["id"]).to eql "e169aa45-1ecf-4183-9955-b1499d5701d3"
+      expect(contacts[:data][0]["first_name"]).to eql "Steve"
+      expect(contacts[:data][0]["last_name"]).to eql "Wozniak"
+      expect(contacts[:data][0]["email"]).to eql "steve.wozniak@gmail.com"
+      expect(contacts[:data][0]["unsubscribed"]).to be false
     end
   end
 
@@ -251,12 +251,12 @@ RSpec.describe "Contacts" do
         "object": "list",
         "data": [
           {
-            "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            "email": "global@example.com",
-            "first_name": "Global",
-            "last_name": "Contact",
-            "created_at": "2023-10-06 23:47:56.678+00",
-            "unsubscribed": false
+            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "global@example.com",
+            "first_name" => "Global",
+            "last_name" => "Contact",
+            "created_at" => "2023-10-06 23:47:56.678+00",
+            "unsubscribed" => false
           }
         ]
       }
@@ -265,8 +265,8 @@ RSpec.describe "Contacts" do
       contacts = Resend::Contacts.list
       expect(contacts[:object]).to eql "list"
       expect(contacts[:data].length).to eql 1
-      expect(contacts[:data][0][:id]).to eql "e169aa45-1ecf-4183-9955-b1499d5701d3"
-      expect(contacts[:data][0][:email]).to eql "global@example.com"
+      expect(contacts[:data][0]["id"]).to eql "e169aa45-1ecf-4183-9955-b1499d5701d3"
+      expect(contacts[:data][0]["email"]).to eql "global@example.com"
     end
 
     it "should update a global contact without audience_id" do

--- a/spec/contacts_topics_spec.rb
+++ b/spec/contacts_topics_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe "Contacts::Topics" do
         "object": "list",
         "data": [
           {
-            "id": topic_id,
-            "name": "Product Updates",
-            "created_at": "2023-10-06 22:59:55.977+00"
+            "id" => topic_id,
+            "name" => "Product Updates",
+            "created_at" => "2023-10-06 22:59:55.977+00"
           }
         ]
       }
@@ -28,8 +28,8 @@ RSpec.describe "Contacts::Topics" do
       topics = Resend::Contacts::Topics.list(id: contact_id)
       expect(topics[:object]).to eql "list"
       expect(topics[:data].length).to eql 1
-      expect(topics[:data][0][:id]).to eql topic_id
-      expect(topics[:data][0][:name]).to eql "Product Updates"
+      expect(topics[:data][0]["id"]).to eql topic_id
+      expect(topics[:data][0]["name"]).to eql "Product Updates"
     end
 
     it "should list topics by contact email" do
@@ -55,9 +55,9 @@ RSpec.describe "Contacts::Topics" do
         "object": "list",
         "data": [
           {
-            "id": topic_id,
-            "name": "Product Updates",
-            "created_at": "2023-10-06 22:59:55.977+00"
+            "id" => topic_id,
+            "name" => "Product Updates",
+            "created_at" => "2023-10-06 22:59:55.977+00"
           }
         ],
         "has_more": true

--- a/spec/domain_claims_spec.rb
+++ b/spec/domain_claims_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe "Domains::Claims" do
         domain_id: "d91cd9bd-1176-453e-8fc1-35364d380206",
         region: "us-east-1",
         record: {
-          type: "TXT",
-          name: "example.com",
-          value: "resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7",
-          ttl: "Auto"
+          "type" => "TXT",
+          "name" => "example.com",
+          "value" => "resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7",
+          "ttl" => "Auto"
         },
         blocked_reason: nil,
         failure_reason: nil,
@@ -35,8 +35,8 @@ RSpec.describe "Domains::Claims" do
       expect(claim[:object]).to eql("domain_claim")
       expect(claim[:status]).to eql("pending")
       expect(claim[:domain_id]).to eql("d91cd9bd-1176-453e-8fc1-35364d380206")
-      expect(claim[:record][:type]).to eql("TXT")
-      expect(claim[:record][:value]).to eql("resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7")
+      expect(claim[:record]["type"]).to eql("TXT")
+      expect(claim[:record]["value"]).to eql("resend-domain-verification=3f8a1c2d4e5b6a7f8091a2b3c4d5e6f7")
     end
 
     it "should pass all options in the request body" do

--- a/spec/domains_spec.rb
+++ b/spec/domains_spec.rb
@@ -18,45 +18,45 @@ RSpec.describe "Domains" do
         "status": "not_started",
         "records": [
           {
-            "record": "SPF",
-            "name": "bounces",
-            "type": "MX",
-            "ttl": "Auto",
-            "status": "not_started",
-            "value": "feedback-smtp.us-east-1.amazonses.com",
-            "priority": 10
+            "record" => "SPF",
+            "name" => "bounces",
+            "type" => "MX",
+            "ttl" => "Auto",
+            "status" => "not_started",
+            "value" => "feedback-smtp.us-east-1.amazonses.com",
+            "priority" => 10
           },
           {
-            "record": "SPF",
-            "name": "bounces",
-            "value": "\"v=spf1 include:amazonses.com ~all\"",
-            "type": "TXT",
-            "ttl": "Auto",
-            "status": "not_started"
+            "record" => "SPF",
+            "name" => "bounces",
+            "value" => "\"v=spf1 include:amazonses.com ~all\"",
+            "type" => "TXT",
+            "ttl" => "Auto",
+            "status" => "not_started"
           },
           {
-            "record": "DKIM",
-            "name": "nhapbbryle57yxg3fbjytyodgbt2kyyg._domainkey",
-            "value": "nhapbbryle57yxg3fbjytyodgbt2kyyg.dkim.amazonses.com.",
-            "type": "CNAME",
-            "status": "not_started",
-            "ttl": "Auto"
+            "record" => "DKIM",
+            "name" => "nhapbbryle57yxg3fbjytyodgbt2kyyg._domainkey",
+            "value" => "nhapbbryle57yxg3fbjytyodgbt2kyyg.dkim.amazonses.com.",
+            "type" => "CNAME",
+            "status" => "not_started",
+            "ttl" => "Auto"
           },
           {
-            "record": "DKIM",
-            "name": "xbakwbe5fcscrhzshpap6kbxesf6pfgn._domainkey",
-            "value": "xbakwbe5fcscrhzshpap6kbxesf6pfgn.dkim.amazonses.com.",
-            "type": "CNAME",
-            "status": "not_started",
-            "ttl": "Auto"
+            "record" => "DKIM",
+            "name" => "xbakwbe5fcscrhzshpap6kbxesf6pfgn._domainkey",
+            "value" => "xbakwbe5fcscrhzshpap6kbxesf6pfgn.dkim.amazonses.com.",
+            "type" => "CNAME",
+            "status" => "not_started",
+            "ttl" => "Auto"
           },
           {
-            "record": "DKIM",
-            "name": "txrcreso3dqbvcve45tqyosxwaegvhgn._domainkey",
-            "value": "txrcreso3dqbvcve45tqyosxwaegvhgn.dkim.amazonses.com.",
-            "type": "CNAME",
-            "status": "not_started",
-            "ttl": "Auto"
+            "record" => "DKIM",
+            "name" => "txrcreso3dqbvcve45tqyosxwaegvhgn._domainkey",
+            "value" => "txrcreso3dqbvcve45tqyosxwaegvhgn.dkim.amazonses.com.",
+            "type" => "CNAME",
+            "status" => "not_started",
+            "ttl" => "Auto"
           }
         ],
         "region": "us-east-1",
@@ -82,37 +82,37 @@ RSpec.describe "Domains" do
         "tracking_subdomain": "links",
         "records": [
           {
-            "record": "SPF",
-            "name": "bounces",
-            "type": "MX",
-            "ttl": "Auto",
-            "status": "not_started",
-            "value": "feedback-smtp.us-east-1.amazonses.com",
-            "priority": 10
+            "record" => "SPF",
+            "name" => "bounces",
+            "type" => "MX",
+            "ttl" => "Auto",
+            "status" => "not_started",
+            "value" => "feedback-smtp.us-east-1.amazonses.com",
+            "priority" => 10
           },
           {
-            "record": "DKIM",
-            "name": "nhapbbryle57yxg3fbjytyodgbt2kyyg._domainkey",
-            "value": "nhapbbryle57yxg3fbjytyodgbt2kyyg.dkim.amazonses.com.",
-            "type": "CNAME",
-            "status": "not_started",
-            "ttl": "Auto"
+            "record" => "DKIM",
+            "name" => "nhapbbryle57yxg3fbjytyodgbt2kyyg._domainkey",
+            "value" => "nhapbbryle57yxg3fbjytyodgbt2kyyg.dkim.amazonses.com.",
+            "type" => "CNAME",
+            "status" => "not_started",
+            "ttl" => "Auto"
           },
           {
-            "record": "Tracking",
-            "name": "links.example.com",
-            "value": "links1.resend-dns.com",
-            "type": "CNAME",
-            "ttl": "Auto",
-            "status": "not_started"
+            "record" => "Tracking",
+            "name" => "links.example.com",
+            "value" => "links1.resend-dns.com",
+            "type" => "CNAME",
+            "ttl" => "Auto",
+            "status" => "not_started"
           },
           {
-            "record": "TrackingCAA",
-            "name": "",
-            "value": "0 issue \"amazon.com\"",
-            "type": "CAA",
-            "ttl": "Auto",
-            "status": "not_started"
+            "record" => "TrackingCAA",
+            "name" => "",
+            "value" => "0 issue \"amazon.com\"",
+            "type" => "CAA",
+            "ttl" => "Auto",
+            "status" => "not_started"
           }
         ],
         "region": "us-east-1",
@@ -129,17 +129,17 @@ RSpec.describe "Domains" do
       expect(domain[:open_tracking]).to be true
       expect(domain[:click_tracking]).to be true
       expect(domain[:tracking_subdomain]).to eql("links")
-      tracking_record = domain[:records].find { |r| r[:record] == "Tracking" }
+      tracking_record = domain[:records].find { |r| r["record"] == "Tracking" }
       expect(tracking_record).not_to be_nil
-      expect(tracking_record[:name]).to eql("links.example.com")
-      expect(tracking_record[:value]).to eql("links1.resend-dns.com")
-      expect(tracking_record[:type]).to eql("CNAME")
-      expect(tracking_record[:ttl]).to eql("Auto")
-      expect(tracking_record[:status]).to eql("not_started")
-      tracking_caa_record = domain[:records].find { |r| r[:record] == "TrackingCAA" }
+      expect(tracking_record["name"]).to eql("links.example.com")
+      expect(tracking_record["value"]).to eql("links1.resend-dns.com")
+      expect(tracking_record["type"]).to eql("CNAME")
+      expect(tracking_record["ttl"]).to eql("Auto")
+      expect(tracking_record["status"]).to eql("not_started")
+      tracking_caa_record = domain[:records].find { |r| r["record"] == "TrackingCAA" }
       expect(tracking_caa_record).not_to be_nil
-      expect(tracking_caa_record[:type]).to eql("CAA")
-      expect(tracking_caa_record[:value]).to eql("0 issue \"amazon.com\"")
+      expect(tracking_caa_record["type"]).to eql("CAA")
+      expect(tracking_caa_record["value"]).to eql("0 issue \"amazon.com\"")
     end
 
     it "should raise when domain is already registered" do
@@ -252,11 +252,11 @@ RSpec.describe "Domains" do
       resp = {
         "data": [
           {
-            "id": "d91cd9bd-1176-453e-8fc1-35364d380206",
-            "name": "example.com",
-            "status": "not_started",
-            "created_at": "2023-04-26 20:21:26.347412+00",
-            "region": "us-east-1"
+            "id" => "d91cd9bd-1176-453e-8fc1-35364d380206",
+            "name" => "example.com",
+            "status" => "not_started",
+            "created_at" => "2023-04-26 20:21:26.347412+00",
+            "region" => "us-east-1"
           }
         ]
       }

--- a/spec/events_spec.rb
+++ b/spec/events_spec.rb
@@ -222,11 +222,11 @@ RSpec.describe "Events" do
         has_more: false,
         data: [
           {
-            id: event_id,
-            name: event_name,
-            schema: nil,
-            created_at: "2024-01-01 00:00:00+00",
-            updated_at: "2024-01-01 00:00:00+00"
+            "id" => event_id,
+            "name" => event_name,
+            "schema" => nil,
+            "created_at" => "2024-01-01 00:00:00+00",
+            "updated_at" => "2024-01-01 00:00:00+00"
           }
         ]
       }
@@ -235,11 +235,11 @@ RSpec.describe "Events" do
       expect(result[:object]).to eql("list")
       expect(result[:data].length).to eql(1)
       expect(result[:has_more]).to eql(false)
-      expect(result[:data].first[:id]).to eql(event_id)
+      expect(result[:data].first["id"]).to eql(event_id)
     end
 
     it "should list events with pagination params" do
-      resp = { object: "list", has_more: true, data: [{ id: event_id }] }
+      resp = { object: "list", has_more: true, data: [{ "id" => event_id }] }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       result = Resend::Events.list({ limit: 1 })
       expect(result[:has_more]).to eql(true)

--- a/spec/logs_spec.rb
+++ b/spec/logs_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "Logs" do
           "method": "POST",
           "response_status": 200,
           "user_agent": "resend-ruby:1.0.0",
-          "request_body": { "from": "user@example.com", "to": "recipient@example.com" },
-          "response_body": { "id": "email_123" }
+          "request_body": { "from" => "user@example.com", "to" => "recipient@example.com" },
+          "response_body": { "id" => "email_123" }
         }
         allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
         result = Resend::Logs.get("3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55")
@@ -77,20 +77,20 @@ RSpec.describe "Logs" do
           "has_more": false,
           "data": [
             {
-              "id": "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
-              "created_at": "2024-11-01 18:10:00+00",
-              "endpoint": "/emails",
-              "method": "POST",
-              "response_status": 200,
-              "user_agent": "resend-ruby:1.0.0"
+              "id" => "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
+              "created_at" => "2024-11-01 18:10:00+00",
+              "endpoint" => "/emails",
+              "method" => "POST",
+              "response_status" => 200,
+              "user_agent" => "resend-ruby:1.0.0"
             },
             {
-              "id": "4e5b583e-cd7e-5ee3-bbae-e4e22c650f66",
-              "created_at": "2024-11-01 17:00:00+00",
-              "endpoint": "/emails",
-              "method": "POST",
-              "response_status": 422,
-              "user_agent": nil
+              "id" => "4e5b583e-cd7e-5ee3-bbae-e4e22c650f66",
+              "created_at" => "2024-11-01 17:00:00+00",
+              "endpoint" => "/emails",
+              "method" => "POST",
+              "response_status" => 422,
+              "user_agent" => nil
             }
           ]
         }
@@ -98,8 +98,8 @@ RSpec.describe "Logs" do
         result = Resend::Logs.list
         expect(result[:data].length).to eql(2)
         expect(result[:has_more]).to eql(false)
-        expect(result[:data].first[:id]).to eql("3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55")
-        expect(result[:data].last[:user_agent]).to be_nil
+        expect(result[:data].first["id"]).to eql("3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55")
+        expect(result[:data].last["user_agent"]).to be_nil
       end
 
       it "should list logs with pagination params" do
@@ -108,12 +108,12 @@ RSpec.describe "Logs" do
           "has_more": true,
           "data": [
             {
-              "id": "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
-              "created_at": "2024-11-01 18:10:00+00",
-              "endpoint": "/emails",
-              "method": "POST",
-              "response_status": 200,
-              "user_agent": "resend-ruby:1.0.0"
+              "id" => "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
+              "created_at" => "2024-11-01 18:10:00+00",
+              "endpoint" => "/emails",
+              "method" => "POST",
+              "response_status" => 200,
+              "user_agent" => "resend-ruby:1.0.0"
             }
           ]
         }
@@ -158,12 +158,12 @@ RSpec.describe "Logs" do
           "has_more": false,
           "data": [
             {
-              "id": "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
-              "created_at": "2024-11-01 18:10:00+00",
-              "endpoint": "/emails",
-              "method": "POST",
-              "response_status": 200,
-              "user_agent": "resend-ruby:1.0.0"
+              "id" => "3d4a472d-bc6d-4dd2-aa9d-d3d11b549e55",
+              "created_at" => "2024-11-01 18:10:00+00",
+              "endpoint" => "/emails",
+              "method" => "POST",
+              "response_status" => 200,
+              "user_agent" => "resend-ruby:1.0.0"
             }
           ]
         }

--- a/spec/oauth_grants_spec.rb
+++ b/spec/oauth_grants_spec.rb
@@ -9,16 +9,16 @@ RSpec.describe "OAuth Grants" do
           "has_more": false,
           "data": [
             {
-              "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-              "client_id": "client_123",
-              "scopes": ["emails:send"],
-              "resource": nil,
-              "created_at": "2023-04-21 01:31:02.671414+00",
-              "revoked_at": nil,
-              "revoked_reason": nil,
-              "client": {
-                "name": "My App",
-                "logo_uri": "https://example.com/logo.png"
+              "id" => "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+              "client_id" => "client_123",
+              "scopes" => ["emails:send"],
+              "resource" => nil,
+              "created_at" => "2023-04-21 01:31:02.671414+00",
+              "revoked_at" => nil,
+              "revoked_reason" => nil,
+              "client" => {
+                "name" => "My App",
+                "logo_uri" => "https://example.com/logo.png"
               }
             }
           ]
@@ -26,7 +26,7 @@ RSpec.describe "OAuth Grants" do
         allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
         grants = Resend::OAuthGrants.list
         expect(grants[:data].length).to eql(1)
-        expect(grants[:data].first[:id]).to eql("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+        expect(grants[:data].first["id"]).to eql("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
         expect(grants[:has_more]).to be(false)
       end
 

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -70,9 +70,9 @@ RSpec.describe "Pagination" do
         "object": "list",
         "data": [
           {
-            "id": "6e3c3d83-05dc-4b51-acfc-fe8972738bd0",
-            "name": "test1",
-            "created_at": "2023-04-21 01:31:02.671414+00"
+            "id" => "6e3c3d83-05dc-4b51-acfc-fe8972738bd0",
+            "name" => "test1",
+            "created_at" => "2023-04-21 01:31:02.671414+00"
           }
         ],
         "has_more": true
@@ -100,8 +100,8 @@ RSpec.describe "Pagination" do
         "object": "list",
         "data": [
           {
-            "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-            "name": "Developers"
+            "id" => "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "name" => "Developers"
           }
         ],
         "has_more": false
@@ -128,8 +128,8 @@ RSpec.describe "Pagination" do
         "object": "list",
         "data": [
           {
-            "id": "b6d24b8e-af0b-4c3c-be0c-359bf9d251d2",
-            "name": "Weekly Newsletter"
+            "id" => "b6d24b8e-af0b-4c3c-be0c-359bf9d251d2",
+            "name" => "Weekly Newsletter"
           }
         ],
         "has_more": true
@@ -155,8 +155,8 @@ RSpec.describe "Pagination" do
         "object": "list",
         "data": [
           {
-            "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            "email": "steve.wozniak@gmail.com"
+            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "steve.wozniak@gmail.com"
           }
         ],
         "has_more": false
@@ -181,8 +181,8 @@ RSpec.describe "Pagination" do
         "object": "list",
         "data": [
           {
-            "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            "email": "steve.wozniak@gmail.com"
+            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "steve.wozniak@gmail.com"
           }
         ],
         "has_more": false
@@ -208,8 +208,8 @@ RSpec.describe "Pagination" do
         "object": "list",
         "data": [
           {
-            "id": "d91cd9bd-1176-453e-8fc1-35364d380206",
-            "name": "example.com"
+            "id" => "d91cd9bd-1176-453e-8fc1-35364d380206",
+            "name" => "example.com"
           }
         ],
         "has_more": true
@@ -236,8 +236,8 @@ RSpec.describe "Pagination" do
         "object": "list",
         "data": [
           {
-            "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-            "name": "Weekly Newsletter"
+            "id" => "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            "name" => "Weekly Newsletter"
           }
         ],
         "has_more": false

--- a/spec/segments_spec.rb
+++ b/spec/segments_spec.rb
@@ -53,9 +53,9 @@ RSpec.describe "Segments" do
         "object": "list",
         "data": [
           {
-            "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-            "name": "Registered Users",
-            "created_at": "2023-10-06 22:59:55.977+00"
+            "id" => "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+            "name" => "Registered Users",
+            "created_at" => "2023-10-06 22:59:55.977+00"
           }
         ]
       }
@@ -64,8 +64,8 @@ RSpec.describe "Segments" do
       expect(segments[:object]).to eql "list"
       expect(segments[:data].empty?).to be false
       expect(segments[:data].length).to eql(1)
-      expect(segments[:data].first[:id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
-      expect(segments[:data].first[:name]).to eql("Registered Users")
+      expect(segments[:data].first["id"]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
+      expect(segments[:data].first["name"]).to eql("Registered Users")
     end
   end
 

--- a/spec/templates_spec.rb
+++ b/spec/templates_spec.rb
@@ -259,22 +259,22 @@ RSpec.describe "Templates" do
         "object": "list",
         "data": [
           {
-            "id": "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            "name": "reset-password",
-            "status": "draft",
-            "published_at": nil,
-            "created_at": "2023-10-06 23:47:56.678+00",
-            "updated_at": "2023-10-06 23:47:56.678+00",
-            "alias": "reset-password"
+            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "name" => "reset-password",
+            "status" => "draft",
+            "published_at" => nil,
+            "created_at" => "2023-10-06 23:47:56.678+00",
+            "updated_at" => "2023-10-06 23:47:56.678+00",
+            "alias" => "reset-password"
           },
           {
-            "id": "b7f9c2e1-1234-4abc-9def-567890abcdef",
-            "name": "welcome-message",
-            "status": "published",
-            "published_at": "2023-10-06 23:47:56.678+00",
-            "created_at": "2023-10-06 23:47:56.678+00",
-            "updated_at": "2023-10-06 23:47:56.678+00",
-            "alias": "welcome-message"
+            "id" => "b7f9c2e1-1234-4abc-9def-567890abcdef",
+            "name" => "welcome-message",
+            "status" => "published",
+            "published_at" => "2023-10-06 23:47:56.678+00",
+            "created_at" => "2023-10-06 23:47:56.678+00",
+            "updated_at" => "2023-10-06 23:47:56.678+00",
+            "alias" => "welcome-message"
           }
         ],
         "has_more": false
@@ -284,15 +284,15 @@ RSpec.describe "Templates" do
       templates = Resend::Templates.list[:data]
 
       expect(templates.length).to eql(2)
-      expect(templates[0][:id]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
-      expect(templates[0][:name]).to eql("reset-password")
-      expect(templates[0][:status]).to eql("draft")
-      expect(templates[0][:alias]).to eql("reset-password")
+      expect(templates[0]["id"]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(templates[0]["name"]).to eql("reset-password")
+      expect(templates[0]["status"]).to eql("draft")
+      expect(templates[0]["alias"]).to eql("reset-password")
 
-      expect(templates[1][:id]).to eql("b7f9c2e1-1234-4abc-9def-567890abcdef")
-      expect(templates[1][:name]).to eql("welcome-message")
-      expect(templates[1][:status]).to eql("published")
-      expect(templates[1][:alias]).to eql("welcome-message")
+      expect(templates[1]["id"]).to eql("b7f9c2e1-1234-4abc-9def-567890abcdef")
+      expect(templates[1]["name"]).to eql("welcome-message")
+      expect(templates[1]["status"]).to eql("published")
+      expect(templates[1]["alias"]).to eql("welcome-message")
     end
 
     it "should list templates with pagination" do

--- a/spec/topics_spec.rb
+++ b/spec/topics_spec.rb
@@ -68,18 +68,18 @@ RSpec.describe "Topics" do
         "has_more": false,
         "data": [
           {
-            "id": "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
-            "name": "Weekly Newsletter",
-            "description": "Weekly newsletter for our subscribers",
-            "default_subscription": "opt_in",
-            "created_at": "2023-04-08 00:11:13.110779+00"
+            "id" => "b6d24b8e-af0b-4c3c-be0c-359bbd97381e",
+            "name" => "Weekly Newsletter",
+            "description" => "Weekly newsletter for our subscribers",
+            "default_subscription" => "opt_in",
+            "created_at" => "2023-04-08 00:11:13.110779+00"
           },
           {
-            "id": "c7e35c9f-1fc2-5db5-cf1d-46af8e4c2f91",
-            "name": "Monthly Updates",
-            "description": "Monthly product updates",
-            "default_subscription": "opt_out",
-            "created_at": "2023-04-09 10:15:20.22089+00"
+            "id" => "c7e35c9f-1fc2-5db5-cf1d-46af8e4c2f91",
+            "name" => "Monthly Updates",
+            "description" => "Monthly product updates",
+            "default_subscription" => "opt_out",
+            "created_at" => "2023-04-09 10:15:20.22089+00"
           }
         ]
       }
@@ -89,17 +89,17 @@ RSpec.describe "Topics" do
 
       expect(topics.length).to eql(2)
 
-      expect(topics[0][:id]).to eql("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
-      expect(topics[0][:name]).to eql("Weekly Newsletter")
-      expect(topics[0][:description]).to eql("Weekly newsletter for our subscribers")
-      expect(topics[0][:default_subscription]).to eql("opt_in")
-      expect(topics[0][:created_at]).to eql("2023-04-08 00:11:13.110779+00")
+      expect(topics[0]["id"]).to eql("b6d24b8e-af0b-4c3c-be0c-359bbd97381e")
+      expect(topics[0]["name"]).to eql("Weekly Newsletter")
+      expect(topics[0]["description"]).to eql("Weekly newsletter for our subscribers")
+      expect(topics[0]["default_subscription"]).to eql("opt_in")
+      expect(topics[0]["created_at"]).to eql("2023-04-08 00:11:13.110779+00")
 
-      expect(topics[1][:id]).to eql("c7e35c9f-1fc2-5db5-cf1d-46af8e4c2f91")
-      expect(topics[1][:name]).to eql("Monthly Updates")
-      expect(topics[1][:description]).to eql("Monthly product updates")
-      expect(topics[1][:default_subscription]).to eql("opt_out")
-      expect(topics[1][:created_at]).to eql("2023-04-09 10:15:20.22089+00")
+      expect(topics[1]["id"]).to eql("c7e35c9f-1fc2-5db5-cf1d-46af8e4c2f91")
+      expect(topics[1]["name"]).to eql("Monthly Updates")
+      expect(topics[1]["description"]).to eql("Monthly product updates")
+      expect(topics[1]["default_subscription"]).to eql("opt_out")
+      expect(topics[1]["created_at"]).to eql("2023-04-09 10:15:20.22089+00")
     end
   end
 

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -124,18 +124,18 @@ RSpec.describe "Webhooks" do
         "has_more": false,
         "data": [
           {
-            "id": "7ab123cd-ef45-6789-abcd-ef0123456789",
-            "created_at": "2023-09-10 10:15:30+00",
-            "status": "disabled",
-            "endpoint": "https://first-webhook.example.com/handler",
-            "events": ["email.delivered", "email.bounced"]
+            "id" => "7ab123cd-ef45-6789-abcd-ef0123456789",
+            "created_at" => "2023-09-10 10:15:30+00",
+            "status" => "disabled",
+            "endpoint" => "https://first-webhook.example.com/handler",
+            "events" => ["email.delivered", "email.bounced"]
           },
           {
-            "id": "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
-            "created_at": "2023-08-22 15:28:00+00",
-            "status": "enabled",
-            "endpoint": "https://second-webhook.example.com/receive",
-            "events": ["email.received"]
+            "id" => "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+            "created_at" => "2023-08-22 15:28:00+00",
+            "status" => "enabled",
+            "endpoint" => "https://second-webhook.example.com/receive",
+            "events" => ["email.received"]
           }
         ]
       }
@@ -147,17 +147,17 @@ RSpec.describe "Webhooks" do
       expect(webhooks[:has_more]).to eql(false)
       expect(webhooks[:data].length).to eql(2)
 
-      expect(webhooks[:data][0][:id]).to eql("7ab123cd-ef45-6789-abcd-ef0123456789")
-      expect(webhooks[:data][0][:status]).to eql("disabled")
-      expect(webhooks[:data][0][:endpoint]).to eql("https://first-webhook.example.com/handler")
-      expect(webhooks[:data][0][:events]).to eql(["email.delivered", "email.bounced"])
-      expect(webhooks[:data][0][:created_at]).to eql("2023-09-10 10:15:30+00")
+      expect(webhooks[:data][0]["id"]).to eql("7ab123cd-ef45-6789-abcd-ef0123456789")
+      expect(webhooks[:data][0]["status"]).to eql("disabled")
+      expect(webhooks[:data][0]["endpoint"]).to eql("https://first-webhook.example.com/handler")
+      expect(webhooks[:data][0]["events"]).to eql(["email.delivered", "email.bounced"])
+      expect(webhooks[:data][0]["created_at"]).to eql("2023-09-10 10:15:30+00")
 
-      expect(webhooks[:data][1][:id]).to eql("4dd369bc-aa82-4ff3-97de-514ae3000ee0")
-      expect(webhooks[:data][1][:status]).to eql("enabled")
-      expect(webhooks[:data][1][:endpoint]).to eql("https://second-webhook.example.com/receive")
-      expect(webhooks[:data][1][:events]).to eql(["email.received"])
-      expect(webhooks[:data][1][:created_at]).to eql("2023-08-22 15:28:00+00")
+      expect(webhooks[:data][1]["id"]).to eql("4dd369bc-aa82-4ff3-97de-514ae3000ee0")
+      expect(webhooks[:data][1]["status"]).to eql("enabled")
+      expect(webhooks[:data][1]["endpoint"]).to eql("https://second-webhook.example.com/receive")
+      expect(webhooks[:data][1]["events"]).to eql(["email.received"])
+      expect(webhooks[:data][1]["created_at"]).to eql("2023-08-22 15:28:00+00")
     end
 
     it "should list webhooks with pagination" do
@@ -166,11 +166,11 @@ RSpec.describe "Webhooks" do
         "has_more": true,
         "data": [
           {
-            "id": "7ab123cd-ef45-6789-abcd-ef0123456789",
-            "created_at": "2023-09-10 10:15:30+00",
-            "status": "enabled",
-            "endpoint": "https://webhook.example.com/handler",
-            "events": ["email.sent"]
+            "id" => "7ab123cd-ef45-6789-abcd-ef0123456789",
+            "created_at" => "2023-09-10 10:15:30+00",
+            "status" => "enabled",
+            "endpoint" => "https://webhook.example.com/handler",
+            "events" => ["email.sent"]
           }
         ]
       }


### PR DESCRIPTION
## Summary

Relates to resend/resend-ruby#206.

`Resend::Request#process_response` symbolizes response keys with a shallow `transform_keys!`. Only the top-level Hash gets Symbol keys. Nested hashes — list `data` entries, batch `data`/`errors` entries, domain `records`, claim `record`, grant `client`, log bodies, automation `steps`/`connections` — keep String keys.

The spec fixtures stubbed Symbol keys everywhere. Because the stubs bypass `process_response`, the suite stayed green while it asserted a shape the API never returns.

This PR updates the fixtures and assertions to match the real response shape. Top-level keys stay Symbols. Nested hashes now use String keys. There is no runtime change, so nothing breaks for callers.

Deep symbolization (option 1 in resend/resend-ruby#206) stays open as a separate, deliberate breaking change.

## Changes

* 21 spec files: nested fixture hashes use String keys; nested-access assertions use String keys.
* `lib/` is untouched. No library code reads nested Symbol keys.
* Request-body fixtures keep Symbol keys — they are SDK inputs, not API responses.
* The newer specs (emails list, attachments, receiving, suppressions, contact import `counts`, template `get`) already modeled reality and are unchanged.

## Verification

Ran in the `ruby:3.4` container: 336 examples, 0 failures; rubocop 39 files, no offenses. Same counts as the 1.7.0 baseline.

---

## Summary by cubic

Updates specs to match real API responses: nested hashes now use String keys, while top-level keys remain Symbols as returned by `Resend::Request#process_response`. Tests only; no runtime or library changes.

* **Refactors**
  * Switched nested fixture keys to String keys and updated related assertions.
  * Left request-body fixtures as Symbols (SDK inputs).

Written for commit 2e89c5e28fa724b522e7ae0bf88a8ea1408596f8. Summary will update on new commits.

![Review in cubic](https://camo.githubusercontent.com/bd9efce2efa0a4d0a92a581dc73a4b2dc621085d3ac789eccf3330c974d2dae0/68747470733a2f2f7777772e63756269632e6465762f627574746f6e732f7265766965772d696e2d63756269632d6461726b2e737667)