### PR TITLE
chore: bump version to 1.8.0

### DIFF
--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
 end


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the library version from 1.7.0 to 1.8.0 to prepare the 1.8.0 release. The gem now reports 1.8.0 instead of 1.7.0 with no runtime behavior changes.

**Review and rollout**
- Only updates the `Resend::VERSION` constant.
- Tag `v1.8.0` and publish the gem after merge.

<sup>Written for commit f98de6d73e2538e134d2af0a3d6b05c5c68d3b5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/218?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

