### PR TITLE
chore: bump

### DIFF
--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "1.8.0"
+  VERSION = "1.9.0"
 end


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bumps the `resend` gem version from 1.8.0 to 1.9.0 to cut a new minor release. No code or runtime behavior changes in this PR; consumers can pin to 1.9.0 to pick up previously merged additions and fixes.

<sup>Written for commit c615425ed54522e473da24e6359ba974cdffe378. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

