### PR TITLE
feat: add Emails.share method

### DIFF
--- a/lib/resend/emails.rb
+++ b/lib/resend/emails.rb
@@ -32,6 +32,17 @@ module Resend
         Resend::Request.new(path, {}, "post").perform
       end
 
+      # Create a shareable link for a sent or received email.
+      #
+      # @param email_id [String] The email id (sent or received).
+      # @param params [Hash] Optional parameters
+      # @option params [String] :expires_in Human-readable duration (e.g. "10m", "2 hours",
+      #   "1 day"). Defaults to "48h" and is capped at 48 hours.
+      def share(email_id, params = {})
+        path = "emails/#{email_id}/share"
+        Resend::Request.new(path, params, "post").perform
+      end
+
       # List emails with optional pagination.
       # see more: https://resend.com/docs/api-reference/emails/list-emails
       #

--- a/spec/emails_spec.rb
+++ b/spec/emails_spec.rb
@@ -69,6 +69,73 @@ RSpec.describe "Emails" do
       expect(email[:id]).to eql "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
     end
 
+    it "shares an email with the default expires_in" do
+      email_id = "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+      resp = {
+        "object": "email",
+        "id": email_id,
+        "url": "https://resend.com/share/#{email_id}"
+      }
+      allow(resp).to receive(:body).and_return(resp)
+      allow(HTTParty).to receive(:send).and_return(resp)
+
+      result = Resend::Emails.share(email_id)
+
+      expect(HTTParty).to have_received(:send).with(
+        :post,
+        "#{Resend::Request::BASE_URL}emails/#{email_id}/share",
+        hash_not_including(:body)
+      )
+      expect(result[:id]).to eql email_id
+      expect(result[:url]).to eql "https://resend.com/share/#{email_id}"
+    end
+
+    it "shares an email with a custom expires_in" do
+      email_id = "49a3999c-0ce1-4ea6-ab68-afcd6dc2e794"
+      resp = {
+        "object": "email",
+        "id": email_id,
+        "url": "https://resend.com/share/#{email_id}"
+      }
+      allow(resp).to receive(:body).and_return(resp)
+      allow(HTTParty).to receive(:send).and_return(resp)
+
+      result = Resend::Emails.share(email_id, expires_in: "10m")
+
+      expect(HTTParty).to have_received(:send).with(
+        :post,
+        "#{Resend::Request::BASE_URL}emails/#{email_id}/share",
+        hash_including(body: { expires_in: "10m" }.to_json)
+      )
+      expect(result[:url]).to eql "https://resend.com/share/#{email_id}"
+    end
+
+    it "raises when expires_in is malformed or exceeds 48 hours" do
+      resp = {
+        "statusCode" => 422,
+        "name" => "validation_error",
+        "message" => "expires_in must not exceed 48h"
+      }
+      allow(resp).to receive(:body).and_return(resp)
+      allow(HTTParty).to receive(:send).and_return(resp)
+
+      expect { Resend::Emails.share("49a3999c-0ce1-4ea6-ab68-afcd6dc2e794", expires_in: "72h") }
+        .to raise_error(Resend::Error::InvalidRequestError, /expires_in must not exceed 48h/)
+    end
+
+    it "raises not found when the email id does not exist" do
+      resp = {
+        "statusCode" => 404,
+        "name" => "not_found",
+        "message" => "Email not found"
+      }
+      allow(resp).to receive(:body).and_return(resp)
+      allow(HTTParty).to receive(:send).and_return(resp)
+
+      expect { Resend::Emails.share("does-not-exist") }
+        .to raise_error(Resend::Error::NotFoundError, /Email not found/)
+    end
+
     it "raises when to is missing" do
       resp = {
         "statusCode"=>422,


### PR DESCRIPTION
Adds `Resend::Emails.share(email_id, params = {})`, calling the new `POST /emails/{id}/share` endpoint that creates a shareable link for a sent or received email. See the spec PR resend/resend-openapi#92.

`params[:expires_in]` is an optional human-readable duration (e.g. `10m`, `2 hours`, `1 day`; server defaults to `48h`, capped at 48h).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `Resend::Emails.share` to create a shareable link for a sent or received email via `POST /emails/{id}/share`. Previously you could not generate share links; now you can optionally set `expires_in` with a human-readable duration. The server defaults to 48h and caps at 48h.

- Posts to `emails/{id}/share`; includes a body only when `expires_in` is provided.
- Returns `id` and `url`. Maps validation and not found responses to existing `Resend::Error` classes.
- Specs cover default expiry, custom `expires_in` ("10m"), invalid durations (>48h), and missing email (404).
- No breaking changes or configuration.

<sup>Written for commit a5f2467fe5eeedff1cfd42c7e9c16a3e63ee83c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/221?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
