### PR TITLE
chore: bump version to 1.10.0

### DIFF
--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "1.9.0"
+  VERSION = "1.10.0"
 end


### PR DESCRIPTION
Bump `Resend::VERSION` to 1.10.0. Minor release covering #222 (add `ApiKeys.update` to rename an API key).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `Resend::VERSION` to 1.10.0 to release `ApiKeys.update` for renaming API keys. Previously the SDK could not rename keys; now you can rename an existing key without rotating it.

**Upgrade notes**
- Upgrade to `resend` 1.10.0 to use `ApiKeys.update`. No breaking changes.

<sup>Written for commit 86207e7637c03e6dca9fdfaf5f4886bfc0374c99. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/223?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

