### PR TITLE
feat: add Broadcasts.recipients method

### DIFF
--- a/examples/broadcasts.rb
+++ b/examples/broadcasts.rb
@@ -74,9 +74,12 @@ puts "retrieved #{retrieved[:id]}"
 puts "html: #{retrieved[:html]}"
 puts "text: #{retrieved[:text]}"
 
-# Note: the broadcast above was only scheduled ("in 1 min"), so this will be
-# empty until it actually sends. Query recipients after delivery in real usage.
-recipients = Resend::Broadcasts.recipients(broadcast[:id], { type: "delivered" })
+# The broadcast above was scheduled ("in 1 min"), so wait for it to actually
+# send before querying recipients. "sent" is the earliest status guaranteed to
+# exist once it fires; "delivered" depends on the receiving server's own
+# timing and isn't guaranteed by any fixed wait.
+sleep 65
+recipients = Resend::Broadcasts.recipients(broadcast[:id], { type: "sent" })
 puts "recipients: #{recipients[:data]}"
 
 if retrieved[:status] == 'draft'

--- a/examples/broadcasts.rb
+++ b/examples/broadcasts.rb
@@ -74,6 +74,8 @@ puts "retrieved #{retrieved[:id]}"
 puts "html: #{retrieved[:html]}"
 puts "text: #{retrieved[:text]}"
 
+# Note: the broadcast above was only scheduled ("in 1 min"), so this will be
+# empty until it actually sends. Query recipients after delivery in real usage.
 recipients = Resend::Broadcasts.recipients(broadcast[:id], { type: "delivered" })
 puts "recipients: #{recipients[:data]}"
 

--- a/examples/broadcasts.rb
+++ b/examples/broadcasts.rb
@@ -74,11 +74,6 @@ puts "retrieved #{retrieved[:id]}"
 puts "html: #{retrieved[:html]}"
 puts "text: #{retrieved[:text]}"
 
-# wait the time for the broadcast to be sent
-sleep 65
-recipients = Resend::Broadcasts.recipients(broadcast[:id], { type: "sent" })
-puts "recipients: #{recipients[:data]}"
-
 if retrieved[:status] == 'draft'
   Resend::Broadcasts.remove(broadcast[:id])
   puts "removed #{broadcast[:id]}"

--- a/examples/broadcasts.rb
+++ b/examples/broadcasts.rb
@@ -74,6 +74,9 @@ puts "retrieved #{retrieved[:id]}"
 puts "html: #{retrieved[:html]}"
 puts "text: #{retrieved[:text]}"
 
+recipients = Resend::Broadcasts.recipients(broadcast[:id], { type: "delivered" })
+puts "recipients: #{recipients[:data]}"
+
 if retrieved[:status] == 'draft'
   Resend::Broadcasts.remove(broadcast[:id])
   puts "removed #{broadcast[:id]}"

--- a/examples/broadcasts.rb
+++ b/examples/broadcasts.rb
@@ -74,10 +74,7 @@ puts "retrieved #{retrieved[:id]}"
 puts "html: #{retrieved[:html]}"
 puts "text: #{retrieved[:text]}"
 
-# The broadcast above was scheduled ("in 1 min"), so wait for it to actually
-# send before querying recipients. "sent" is the earliest status guaranteed to
-# exist once it fires; "delivered" depends on the receiving server's own
-# timing and isn't guaranteed by any fixed wait.
+# wait the time for the broadcast to be sent
 sleep 65
 recipients = Resend::Broadcasts.recipients(broadcast[:id], { type: "sent" })
 puts "recipients: #{recipients[:data]}"

--- a/lib/resend/broadcasts.rb
+++ b/lib/resend/broadcasts.rb
@@ -57,6 +57,25 @@ module Resend
         path = "broadcasts/#{broadcast_id}"
         Resend::Request.new(path, {}, "get").perform
       end
+
+      # https://resend.com/docs/api-reference/broadcasts/list-broadcast-recipients
+      # @param broadcast_id [String] the broadcast id
+      # @param params [Hash] the parameters
+      # @option params [String] :type the recipient event type to filter by (required):
+      #   sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed
+      # @option params [String] :email filter recipients by email address (optional)
+      # @option params [String] :bounce_type filter bounced recipients by bounce type (optional,
+      #   only valid when type is bounced): permanent, transient, undetermined
+      # @option params [Integer] :limit the maximum number of results to return (optional)
+      # @option params [String] :after the cursor for pagination (optional)
+      # @option params [String] :before the cursor for pagination (optional)
+      def recipients(broadcast_id = "", params = {})
+        raise ArgumentError, "type is required" if params[:type].nil?
+
+        base_path = "broadcasts/#{broadcast_id}/recipients"
+        path = Resend::PaginationHelper.build_paginated_path(base_path, params)
+        Resend::Request.new(path, {}, "get").perform
+      end
     end
   end
 end

--- a/spec/broadcasts_spec.rb
+++ b/spec/broadcasts_spec.rb
@@ -168,6 +168,131 @@ RSpec.describe "Broadcasts" do
     end
   end
 
+  describe "recipients" do
+    it "should raise when type is missing" do
+      expect do
+        Resend::Broadcasts.recipients("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", {})
+      end.to raise_error(ArgumentError, "type is required")
+    end
+
+    it "should list recipients for a basic event type" do
+      resp = {
+        "object": "list",
+        "has_more": false,
+        "data": [
+          {
+            "id" => "b2Zmc2V0OjA",
+            "contact_id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "carter@example.com"
+          }
+        ]
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+
+      recipients = Resend::Broadcasts.recipients(
+        "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
+        { type: "sent" }
+      )
+
+      expect(recipients[:object]).to eql("list")
+      expect(recipients[:has_more]).to eql(false)
+      expect(recipients[:data].length).to eql(1)
+      expect(recipients[:data][0]["id"]).to eql("b2Zmc2V0OjA")
+      expect(recipients[:data][0]["contact_id"]).to eql("e169aa45-1ecf-4183-9955-b1499d5701d3")
+      expect(recipients[:data][0]["email"]).to eql("carter@example.com")
+    end
+
+    it "should list recipients with count for opened type" do
+      resp = {
+        "object": "list",
+        "has_more": false,
+        "data": [
+          {
+            "id" => "b2Zmc2V0OjA",
+            "contact_id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "carter@example.com",
+            "count" => 3
+          }
+        ]
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+
+      recipients = Resend::Broadcasts.recipients(
+        "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
+        { type: "opened" }
+      )
+
+      expect(recipients[:data][0]["count"]).to eql(3)
+    end
+
+    it "should list recipients with clicked_links for clicked type" do
+      resp = {
+        "object": "list",
+        "has_more": false,
+        "data": [
+          {
+            "id" => "b2Zmc2V0OjA",
+            "contact_id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
+            "email" => "carter@example.com",
+            "count" => 2,
+            "clicked_links" => [
+              { "url" => "https://resend.com/pricing", "clicks" => 2 }
+            ]
+          }
+        ]
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+
+      recipients = Resend::Broadcasts.recipients(
+        "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
+        { type: "clicked" }
+      )
+
+      expect(recipients[:data][0]["count"]).to eql(2)
+      expect(recipients[:data][0]["clicked_links"]).to eql(
+        [{ "url" => "https://resend.com/pricing", "clicks" => 2 }]
+      )
+    end
+
+    it "should list recipients with bounce_type for bounced type" do
+      resp = {
+        "object": "list",
+        "has_more": false,
+        "data": [
+          {
+            "id" => "b2Zmc2V0OjA",
+            "contact_id" => nil,
+            "email" => "carter@example.com",
+            "bounce_type" => "permanent"
+          }
+        ]
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+
+      recipients = Resend::Broadcasts.recipients(
+        "559ac32e-9ef5-46fb-82a1-b76b840c0f7b",
+        { type: "bounced", bounce_type: "permanent" }
+      )
+
+      expect(recipients[:data][0]["contact_id"]).to eql(nil)
+      expect(recipients[:data][0]["bounce_type"]).to eql("permanent")
+    end
+
+    it "should raise when broadcast is not found" do
+      resp = {
+        "statusCode" => 404,
+        "name" => "not_found",
+        "message" => "Broadcast not found"
+      }
+      allow(resp).to receive(:body).and_return(resp)
+      allow(HTTParty).to receive(:send).and_return(resp)
+
+      expect do
+        Resend::Broadcasts.recipients("missing-id", { type: "sent" })
+      end.to raise_error(Resend::Error::NotFoundError, /Broadcast not found/)
+    end
+  end
+
   describe "get broadcast" do
 
     it "should retrieve a broadcast" do

--- a/spec/broadcasts_spec.rb
+++ b/spec/broadcasts_spec.rb
@@ -187,6 +187,11 @@ RSpec.describe "Broadcasts" do
           }
         ]
       }
+      expect(Resend::Request).to receive(:new).with(
+        "broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients?type=sent",
+        {},
+        "get"
+      ).and_call_original
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
 
       recipients = Resend::Broadcasts.recipients(
@@ -267,6 +272,11 @@ RSpec.describe "Broadcasts" do
           }
         ]
       }
+      expect(Resend::Request).to receive(:new).with(
+        "broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/recipients?type=bounced&bounce_type=permanent",
+        {},
+        "get"
+      ).and_call_original
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
 
       recipients = Resend::Broadcasts.recipients(


### PR DESCRIPTION
Adds `Resend::Broadcasts.recipients(id, params)` for `GET /broadcasts/{id}/recipients`.

Spec: https://github.com/resend/resend-openapi/pull/97
Node reference: https://github.com/resend/resend-node/pull/1078

Tests: 357 passed. rubocop clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Resend::Broadcasts.recipients(id, params) to list broadcast recipients via GET /broadcasts/{id}/recipients. Previously the SDK could not fetch recipients; now clients can filter by event type and paginate, and 404s raise Resend::Error::NotFoundError. Removes the recipients example that required an arbitrary sleep.

- Require params[:type] (sent, delivered, opened, clicked, bounced, complained, unsubscribed, suppressed); raise ArgumentError if missing.
- Support filters: email; bounce_type when type is 'bounced' (permanent, transient, undetermined); limit, after, before via Resend::PaginationHelper.
- Return extra fields by type: opened includes count; clicked includes count and clicked_links; bounced includes bounce_type.
- Tests verify request paths, per-type fields, and that 404 raises NotFoundError.

<sup>Written for commit b6c8b67f4a138ad55f896f5f9a238d64cceb26d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/224?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

