### PR TITLE
feat: add broadcasts.clicked_links() method

### DIFF
--- a/lib/resend/broadcasts.rb
+++ b/lib/resend/broadcasts.rb
@@ -41,6 +41,12 @@ module Resend
         Resend::Request.new(path, {}, "get").perform
       end
 
+      # https://resend.com/docs/api-reference/broadcasts/list-broadcast-clicked-links
+      def clicked_links(broadcast_id = "", params = {})
+        path = Resend::PaginationHelper.build_paginated_path("broadcasts/#{broadcast_id}/clicked-links", params)
+        Resend::Request.new(path, {}, "get").perform
+      end
+
       def cancel(broadcast_id = "")
         path = "broadcasts/#{broadcast_id}/cancel"
         Resend::Request.new(path, {}, "post").perform

--- a/spec/broadcasts_spec.rb
+++ b/spec/broadcasts_spec.rb
@@ -147,6 +147,60 @@ RSpec.describe "Broadcasts" do
     end
   end
 
+  describe "clicked_links" do
+    it "should list a broadcast's clicked links" do
+      resp = {
+        "object": "list",
+        "has_more": false,
+        "data": [
+          {
+            "id" => "b2Zmc2V0OjA",
+            "url" => "https://resend.com/pricing",
+            "clicks" => 42,
+            "unique_clicks" => 30
+          },
+          {
+            "id" => "b2Zmc2V0OjE",
+            "url" => "https://resend.com/docs",
+            "clicks" => 17,
+            "unique_clicks" => 15
+          }
+        ]
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+
+      result = Resend::Broadcasts.clicked_links("559ac32e-9ef5-46fb-82a1-b76b840c0f7b")
+
+      expect(result[:object]).to eql("list")
+      expect(result[:has_more]).to eql(false)
+      expect(result[:data].length).to eql(2)
+      expect(result[:data][0]["url"]).to eql("https://resend.com/pricing")
+      expect(result[:data][0]["clicks"]).to eql(42)
+      expect(result[:data][0]["unique_clicks"]).to eql(30)
+    end
+
+    it "should accept pagination parameters" do
+      resp = {
+        "object": "list",
+        "has_more": false,
+        "data": []
+      }
+
+      request_instance = instance_double(Resend::Request)
+      allow(request_instance).to receive(:perform).and_return(resp)
+      allow(Resend::Request).to receive(:new) do |path, _body, _verb|
+        expect(path).to include("broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links")
+        expect(path).to include("limit=10")
+        expect(path).to include("after=key_123")
+        request_instance
+      end
+
+      params = { limit: 10, after: "key_123" }
+      result = Resend::Broadcasts.clicked_links("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", params)
+      expect(result[:object]).to eql("list")
+    end
+  end
+
   describe "cancel" do
     it "should cancel broadcast" do
       resp = {

--- a/spec/broadcasts_spec.rb
+++ b/spec/broadcasts_spec.rb
@@ -192,10 +192,11 @@ RSpec.describe "Broadcasts" do
         expect(path).to include("broadcasts/559ac32e-9ef5-46fb-82a1-b76b840c0f7b/clicked-links")
         expect(path).to include("limit=10")
         expect(path).to include("after=key_123")
+        expect(path).to include("before=key_456")
         request_instance
       end
 
-      params = { limit: 10, after: "key_123" }
+      params = { limit: 10, after: "key_123", before: "key_456" }
       result = Resend::Broadcasts.clicked_links("559ac32e-9ef5-46fb-82a1-b76b840c0f7b", params)
       expect(result[:object]).to eql("list")
     end

--- a/spec/broadcasts_spec.rb
+++ b/spec/broadcasts_spec.rb
@@ -148,7 +148,7 @@ RSpec.describe "Broadcasts" do
   end
 
   describe "clicked_links" do
-    it "should list a broadcast's clicked links" do
+    it "lists a broadcast's clicked links" do
       resp = {
         "object": "list",
         "has_more": false,
@@ -179,7 +179,7 @@ RSpec.describe "Broadcasts" do
       expect(result[:data][0]["unique_clicks"]).to eql(30)
     end
 
-    it "should accept pagination parameters" do
+    it "accepts pagination parameters" do
       resp = {
         "object": "list",
         "has_more": false,


### PR DESCRIPTION
Adds `GET /broadcasts/{id}/clicked-links` — paginated list of a broadcast's clicked links (`url`, `clicks`, `unique_clicks`).

Spec: resend/resend-openapi#95
Reference implementation: resend/resend-node#1077

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `Resend::Broadcasts.clicked_links` to list a broadcast’s clicked links via `GET /broadcasts/{id}/clicked-links`, enabling paginated click analytics. No behavior changes to existing methods.

- Returns a paginated list of link objects with `id`, `url`, `clicks`, and `unique_clicks`.
- Forwards `limit`, `after`, and `before` via `Resend::PaginationHelper`; specs cover response shape and all pagination params.

<sup>Written for commit 9b0d877eebcc7cdf17da6a7a61c103f1a2e400a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

