### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resend (1.10.0)
+    resend (1.11.0)
       base64
       httparty (>= 0.22.0)
 

--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "1.10.0"
+  VERSION = "1.11.0"
 end


### PR DESCRIPTION
Bumps the version for the release that ships:
- Emails.metrics (#225)
- Broadcasts.recipients (#224)
- broadcasts.clicked_links (#226)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases `resend` 1.11.0 to expose new email and broadcast metrics endpoints. Previously these endpoints were unavailable; existing APIs are unchanged.

**What’s included**
- Support for Emails.metrics.
- Support for Broadcasts.recipients and broadcasts.clicked_links.
- Aligns `Gemfile.lock` to 1.11.0 to match the version bump.

**Migration**
- Update your dependency to `resend` 1.11.0; no other changes required.

<sup>Written for commit 3e04f2a78460654089b0b85056044618cd8b31ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/228?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

