### PR TITLE
feat(webhooks): add event listing endpoints

### DIFF
--- a/lib/resend/webhooks.rb
+++ b/lib/resend/webhooks.rb
@@ -84,6 +84,22 @@ module Resend
         Resend::Request.new(path, {}, "get").perform
       end
 
+      def list_events(webhook_id, params = {})
+        path = Resend::PaginationHelper.build_paginated_path("webhooks/#{webhook_id}/events", params)
+        Resend::Request.new(path, {}, "get").perform
+      end
+
+      def get_event(webhook_id, event_id)
+        path = "webhooks/#{webhook_id}/events/#{event_id}"
+        Resend::Request.new(path, {}, "get").perform
+      end
+
+      def list_event_attempts(webhook_id, event_id, params = {})
+        base_path = "webhooks/#{webhook_id}/events/#{event_id}/attempts"
+        path = Resend::PaginationHelper.build_paginated_path(base_path, params)
+        Resend::Request.new(path, {}, "get").perform
+      end
+
       # Update an existing webhook configuration
       #
       # @param params [Hash] The webhook update parameters

--- a/lib/resend/webhooks.rb
+++ b/lib/resend/webhooks.rb
@@ -84,16 +84,59 @@ module Resend
         Resend::Request.new(path, {}, "get").perform
       end
 
+      # Retrieve webhook events
+      #
+      # @param webhook_id [String] The webhook ID
+      # @param params [Hash] The pagination parameters
+      # @option params [Integer] :limit Number of webhook events to retrieve (max: 100, min: 1)
+      # @option params [String] :after The ID after which to retrieve more webhook events
+      #
+      # @return [Hash] A paginated list of webhook events
+      #
+      # @example
+      #   Resend::Webhooks.list_events("4dd369bc-aa82-4ff3-97de-514ae3000ee0")
+      #
+      # @example With pagination
+      #   Resend::Webhooks.list_events("4dd369bc-aa82-4ff3-97de-514ae3000ee0", limit: 20, after: "msg_123")
       def list_events(webhook_id, params = {})
         path = Resend::PaginationHelper.build_paginated_path("webhooks/#{webhook_id}/events", params)
         Resend::Request.new(path, {}, "get").perform
       end
 
+      # Retrieve a webhook event
+      #
+      # @param webhook_id [String] The webhook ID
+      # @param event_id [String] The webhook event ID
+      #
+      # @return [Hash] The webhook event with full details
+      #
+      # @example
+      #   Resend::Webhooks.get_event("4dd369bc-aa82-4ff3-97de-514ae3000ee0", "msg_123")
       def get_event(webhook_id, event_id)
         path = "webhooks/#{webhook_id}/events/#{event_id}"
         Resend::Request.new(path, {}, "get").perform
       end
 
+      # Retrieve delivery attempts for a webhook event
+      #
+      # @param webhook_id [String] The webhook ID
+      # @param event_id [String] The webhook event ID
+      # @param params [Hash] The pagination parameters
+      # @option params [Integer] :limit Number of delivery attempts to retrieve (max: 100, min: 1)
+      # @option params [String] :after The ID after which to retrieve more delivery attempts
+      #
+      # @return [Hash] A paginated list of webhook event delivery attempts
+      #
+      # @example
+      #   Resend::Webhooks.list_event_attempts("4dd369bc-aa82-4ff3-97de-514ae3000ee0", "msg_123")
+      #
+      # @example With pagination
+      #   Resend::Webhooks.list_event_attempts(
+      #     "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
+      #     "msg_123",
+      #     limit: 20,
+      #     after: "atmpt_123"
+      #   )
       def list_event_attempts(webhook_id, event_id, params = {})
         base_path = "webhooks/#{webhook_id}/events/#{event_id}/attempts"
         path = Resend::PaginationHelper.build_paginated_path(base_path, params)

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -80,6 +80,53 @@ RSpec.describe "Webhooks" do
     end
   end
 
+  describe "list_events" do
+    it "should list webhook events with pagination" do
+      request = instance_double(Resend::Request)
+      expect(Resend::Request).to receive(:new)
+        .with("webhooks/webhook_123/events?limit=1&after=msg_1srOrx2ZWZBpBUvZwXKQmoEYga2", {}, "get")
+        .and_return(request)
+      expect(request).to receive(:perform)
+
+      Resend::Webhooks.list_events(
+        "webhook_123", limit: 1, after: "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
+      )
+    end
+  end
+
+  describe "get_event" do
+    it "should retrieve a webhook event" do
+      request = instance_double(Resend::Request)
+      expect(Resend::Request).to receive(:new)
+        .with("webhooks/webhook_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2", {}, "get")
+        .and_return(request)
+      expect(request).to receive(:perform)
+
+      Resend::Webhooks.get_event("webhook_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2")
+    end
+  end
+
+  describe "list_event_attempts" do
+    it "should list webhook event attempts with pagination" do
+      request = instance_double(Resend::Request)
+      expect(Resend::Request).to receive(:new)
+        .with(
+          "webhooks/webhook_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/attempts?limit=10&after=atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd",
+          {},
+          "get"
+        )
+        .and_return(request)
+      expect(request).to receive(:perform)
+
+      Resend::Webhooks.list_event_attempts(
+        "webhook_123",
+        "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2",
+        limit: 10,
+        after: "atmpt_2ZbUCwvGmIT4mLIN6d3Yz0Ainbd"
+      )
+    end
+  end
+
   describe "update" do
     it "should update webhook" do
       resp = {

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe "Webhooks" do
   end
 
   describe "list_events" do
-    it "should list webhook events with pagination" do
+    it "lists webhook events with pagination" do
       request = instance_double(Resend::Request)
       expect(Resend::Request).to receive(:new)
         .with("webhooks/webhook_123/events?limit=1&after=msg_1srOrx2ZWZBpBUvZwXKQmoEYga2", {}, "get")
@@ -95,7 +95,7 @@ RSpec.describe "Webhooks" do
   end
 
   describe "get_event" do
-    it "should retrieve a webhook event" do
+    it "retrieves a webhook event" do
       request = instance_double(Resend::Request)
       expect(Resend::Request).to receive(:new)
         .with("webhooks/webhook_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2", {}, "get")
@@ -107,7 +107,7 @@ RSpec.describe "Webhooks" do
   end
 
   describe "list_event_attempts" do
-    it "should list webhook event attempts with pagination" do
+    it "lists webhook event attempts with pagination" do
       request = instance_double(Resend::Request)
       expect(Resend::Request).to receive(:new)
         .with(


### PR DESCRIPTION
Adds methods for listing webhook events, retrieving an event, and listing delivery attempts, including pagination support.

Linear: https://linear.app/resend/issue/DEV-1925

Tests: full specs, RuboCop, and live API calls.