### PR TITLE
feat: add Segments.update method to rename a segment

### DIFF
--- a/lib/resend/segments.rb
+++ b/lib/resend/segments.rb
@@ -16,6 +16,12 @@ module Resend
         Resend::Request.new(path, {}, "get").perform
       end
 
+      # https://resend.com/docs/api-reference/segments/update-segment
+      def update(params = {})
+        path = "segments/#{params[:segment_id]}"
+        Resend::Request.new(path, params, "patch").perform
+      end
+
       # https://resend.com/docs/api-reference/segments/list-segments
       def list(params = {})
         path = Resend::PaginationHelper.build_paginated_path("segments", params)

--- a/lib/resend/segments.rb
+++ b/lib/resend/segments.rb
@@ -19,7 +19,7 @@ module Resend
       # https://resend.com/docs/api-reference/segments/update-segment
       def update(params = {})
         path = "segments/#{params[:segment_id]}"
-        Resend::Request.new(path, params, "patch").perform
+        Resend::Request.new(path, { name: params[:name] }, "patch").perform
       end
 
       # https://resend.com/docs/api-reference/segments/list-segments

--- a/spec/segments_spec.rb
+++ b/spec/segments_spec.rb
@@ -47,6 +47,25 @@ RSpec.describe "Segments" do
     end
   end
 
+  describe "update segment" do
+    it "should update segment" do
+      resp = {
+        "object": "segment",
+        "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+        "name": "Registered Users - Updated"
+      }
+      params = {
+        "segment_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
+        "name": "Registered Users - Updated"
+      }
+      allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+      segment = Resend::Segments.update(params)
+      expect(segment[:object]).to eql("segment")
+      expect(segment[:id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
+      expect(segment[:name]).to eql("Registered Users - Updated")
+    end
+  end
+
   describe "list segments" do
     it "should list segments" do
       resp = {

--- a/spec/segments_spec.rb
+++ b/spec/segments_spec.rb
@@ -49,13 +49,12 @@ RSpec.describe "Segments" do
 
   describe "update segment" do
     it "should update segment" do
-      resp = { "object": "segment", "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf", "name": "Registered Users - Updated" }
+      resp = { "object": "segment", "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf" }
       params = { "segment_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf", "name": "Registered Users - Updated" }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       segment = Resend::Segments.update(params)
       expect(segment[:object]).to eql("segment")
       expect(segment[:id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
-      expect(segment[:name]).to eql("Registered Users - Updated")
     end
     it "should use PATCH segments/:segment_id and exclude segment_id from the body" do
       params = { segment_id: "78261eea-8f8b-4381-83c6-79fa7120f1cf", name: "Registered Users - Updated" }

--- a/spec/segments_spec.rb
+++ b/spec/segments_spec.rb
@@ -49,20 +49,23 @@ RSpec.describe "Segments" do
 
   describe "update segment" do
     it "should update segment" do
-      resp = {
-        "object": "segment",
-        "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-        "name": "Registered Users - Updated"
-      }
-      params = {
-        "segment_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
-        "name": "Registered Users - Updated"
-      }
+      resp = { "object": "segment", "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf", "name": "Registered Users - Updated" }
+      params = { "segment_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf", "name": "Registered Users - Updated" }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
       segment = Resend::Segments.update(params)
       expect(segment[:object]).to eql("segment")
       expect(segment[:id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
       expect(segment[:name]).to eql("Registered Users - Updated")
+    end
+    it "should use PATCH segments/:segment_id" do
+      params = { segment_id: "78261eea-8f8b-4381-83c6-79fa7120f1cf", name: "Registered Users - Updated" }
+      req = double("req", perform: { id: params[:segment_id] })
+      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+        expect(path).to eql("segments/#{params[:segment_id]}")
+        expect(verb).to eql("patch")
+        req
+      end
+      Resend::Segments.update(params)
     end
   end
 

--- a/spec/segments_spec.rb
+++ b/spec/segments_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe "Segments" do
   end
 
   describe "update segment" do
-    it "should update segment" do
+    it "updates segment" do
       resp = { "object": "segment", "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf" }
       params = { "segment_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf", "name": "Registered Users - Updated" }
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)

--- a/spec/segments_spec.rb
+++ b/spec/segments_spec.rb
@@ -57,12 +57,14 @@ RSpec.describe "Segments" do
       expect(segment[:id]).to eql("78261eea-8f8b-4381-83c6-79fa7120f1cf")
       expect(segment[:name]).to eql("Registered Users - Updated")
     end
-    it "should use PATCH segments/:segment_id" do
+    it "should use PATCH segments/:segment_id and exclude segment_id from the body" do
       params = { segment_id: "78261eea-8f8b-4381-83c6-79fa7120f1cf", name: "Registered Users - Updated" }
       req = double("req", perform: { id: params[:segment_id] })
-      expect(Resend::Request).to receive(:new).once do |path, _body, verb|
+      expect(Resend::Request).to receive(:new).once do |path, body, verb|
         expect(path).to eql("segments/#{params[:segment_id]}")
         expect(verb).to eql("patch")
+        expect(body).not_to have_key(:segment_id)
+        expect(body[:name]).to eql("Registered Users - Updated")
         req
       end
       Resend::Segments.update(params)


### PR DESCRIPTION
Adds `Resend::Segments.update` to rename a segment via `PATCH /segments/:id`, mirroring the existing `Resend::Topics.update` pattern.

```ruby
Resend.api_key = ENV["RESEND_API_KEY"]

params = {
  "segment_id": "78261eea-8f8b-4381-83c6-79fa7120f1cf",
  "name": "Registered Users - Updated"
}

Resend::Segments.update(params)
```

**Params**
- `name` (string, required) — the new segment name

**Response**
```json
{
  "object": "segment",
  "id": "78261eea-8f8b-4381-83c6-79fa7120f1cf"
}
```