### PR TITLE
chore: bump version to 1.12.0

### DIFF
--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "1.11.0"
+  VERSION = "1.12.0"
 end


### PR DESCRIPTION
Bump `Resend::VERSION` to 1.12.0. Minor release covering #230 (`Segments.update`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `Resend::VERSION` to `1.12.0` for the next minor release, which ships the `Segments.update` feature from #230.

<sup>Written for commit 38882bade2c3922cd3749ed71a99dcb88a102276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/231?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

