### PR TITLE
chore: bump version to 1.13.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    resend (1.11.0)
+    resend (1.13.0)
       base64
       httparty (>= 0.22.0)
 

--- a/lib/resend/version.rb
+++ b/lib/resend/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Resend
-  VERSION = "1.12.0"
+  VERSION = "1.13.0"
 end


### PR DESCRIPTION
Bump the client version to 1.13.0. Minor release covering #229 (webhook event listing endpoints).

Linear: https://linear.app/resend/issue/DEV-1925

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps the client version from 1.12.0 to 1.13.0. This minor release adds webhook event listing endpoints, covering DEV-1925.

- Syncs the lockfile, which was still on 1.11.0, to 1.13.0.

<sup>Written for commit 7aeede288a6df191d4746d6d7172ca533b7c60a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

