### PR TITLE
docs(webhooks): add event listing examples

### DIFF
--- a/examples/webhooks.rb
+++ b/examples/webhooks.rb
@@ -58,6 +58,25 @@ if webhooks[:data] && webhooks[:data].length > 0
   puts "Has more: #{paginated_webhooks[:has_more]}"
 end
 
+# List webhook events
+webhook_events = Resend::Webhooks.list_events(webhook[:id], limit: 10)
+puts "\nWebhook events: #{webhook_events[:data].length}"
+puts "Has more: #{webhook_events[:has_more]}"
+
+if webhook_events[:data].any?
+  event_id = webhook_events[:data].first["id"]
+
+  # Retrieve a webhook event
+  webhook_event = Resend::Webhooks.get_event(webhook[:id], event_id)
+  puts "\nWebhook event: #{webhook_event[:id]}"
+  puts "Status: #{webhook_event[:status]}"
+
+  # List delivery attempts for a webhook event
+  attempts = Resend::Webhooks.list_event_attempts(webhook[:id], event_id, limit: 10)
+  puts "\nDelivery attempts: #{attempts[:data].length}"
+  puts "Has more: #{attempts[:has_more]}"
+end
+
 # Remove the webhook
 removed_webhook = Resend::Webhooks.remove(webhook[:id])
 puts "\nRemoved webhook: #{removed_webhook[:id]}"


### PR DESCRIPTION
## Summary

- add examples for listing webhook events
- add examples for retrieving an event and listing its delivery attempts

## Testing

- `NO_COLOR=1 bundle exec rake`

Linear: https://linear.app/resend/issue/DEV-1925

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds webhook event listing examples to `examples/webhooks.rb` to match the Node SDK and complete the DEV-1925 documentation update.

- Shows how to list webhook events, retrieve a single event, and list its delivery attempts.
- No behavior changes; examples only run when the script is executed.

<sup>Written for commit 7afdf9050e69f52d1d3a282d0500fada55209c61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/233?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

