### PR TITLE
Add Action Mailbox ingress for receiving emails in Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,43 @@ mailer = UserMailer.with(user: u).welcome_email
 mailer.deliver_now!
 # => {:id=>"b8f94710-0d84-429c-925a-22d3d8f86916", from: 'you@yourdomain.io', to: ["example2@mail.com", "example1@mail.com"]}
 ```
+
+# Rails and ActionMailbox support
+
+This gem also provides an Action Mailbox ingress, so you can receive inbound emails through Resend.
+
+Configure Action Mailbox to use the Resend ingress, and make sure your API key is set (it is used to fetch the full message and its attachments):
+
+```ruby
+# config/environments/production.rb
+config.action_mailbox.ingress = :resend
+```
+
+```ruby
+# config/initializers/resend.rb
+Resend.api_key = "re_123456"
+```
+
+Resend delivers inbound emails as `email.received` webhooks. Create a webhook in the [Resend dashboard](https://resend.com/webhooks) (or via `Resend::Webhooks.create`) subscribed to the `email.received` event and pointed at your app:
+
+```
+https://example.com/rails/action_mailbox/resend/inbound_emails
+```
+
+Then store the webhook's signing secret (`whsec_...`) so the ingress can verify incoming requests. Either add it to your encrypted credentials with `bin/rails credentials:edit`:
+
+```yml
+action_mailbox:
+  resend_signing_secret: whsec_...
+```
+
+or provide it through the `RESEND_INGRESS_SIGNING_SECRET` environment variable.
+
+Each verified webhook is turned back into a full email — using Resend's raw message download when available, and otherwise rebuilding the message from the Received Emails and Attachments APIs — and handed to Action Mailbox for routing like any other ingress:
+
+```ruby
+# app/mailboxes/application_mailbox.rb
+class ApplicationMailbox < ActionMailbox::Base
+  routing /^support@/i => :support
+end
+```

--- a/app/controllers/action_mailbox/ingresses/resend/inbound_emails_controller.rb
+++ b/app/controllers/action_mailbox/ingresses/resend/inbound_emails_controller.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module ActionMailbox
+  module Ingresses
+    module Resend
+      # Ingests inbound emails delivered by Resend's +email.received+ webhook.
+      #
+      # Resend webhooks only carry the received email's metadata, so the full message
+      # (including any attachments) is fetched from the Resend API before being enqueued
+      # for routing. The webhook request is authenticated by verifying its Svix signature
+      # against the webhook's signing secret, which is stored in the
+      # +action_mailbox.resend_signing_secret+ Rails credential or the
+      # +RESEND_INGRESS_SIGNING_SECRET+ environment variable.
+      #
+      # Returns:
+      #
+      # - <tt>204 No Content</tt> if an inbound email is successfully recorded and enqueued for
+      #   routing, or if the event is not an +email.received+ event and was ignored
+      # - <tt>401 Unauthorized</tt> if the request's signature could not be validated
+      # - <tt>404 Not Found</tt> if Action Mailbox is not configured to accept inbound emails
+      #   from Resend
+      # - <tt>422 Unprocessable Entity</tt> if the request's payload is malformed
+      # - <tt>500 Server Error</tt> if the webhook signing secret is missing, the Resend API
+      #   could not be reached, or one of the Active Record database, the Active Storage
+      #   service, or the Active Job backend is misconfigured or unavailable
+      class InboundEmailsController < ActionMailbox::BaseController
+        before_action :authenticate
+
+        def create
+          return head :no_content unless email_received_event?
+          return head :unprocessable_entity if email_id.nil?
+
+          ActionMailbox::InboundEmail.create_and_extract_message_id! raw_email
+          head :no_content
+        rescue JSON::ParserError => e
+          logger.error e.message
+          head :unprocessable_entity
+        end
+
+        private
+
+        def raw_email
+          ::Resend::ActionMailbox::MessageBuilder.new(email_id).raw_email
+        end
+
+        def email_received_event?
+          event["type"] == "email.received"
+        end
+
+        def email_id
+          event.dig("data", "email_id")
+        end
+
+        def event
+          @event ||= JSON.parse(request.raw_post)
+        end
+
+        def authenticate
+          head :unauthorized unless authenticated?
+        end
+
+        def authenticated?
+          if signing_secret.present?
+            verified_signature?
+          else
+            raise ArgumentError, <<~MESSAGE.squish
+              Missing required Resend webhook signing secret. Set action_mailbox.resend_signing_secret
+              in your application's encrypted credentials or provide the RESEND_INGRESS_SIGNING_SECRET
+              environment variable.
+            MESSAGE
+          end
+        end
+
+        def verified_signature?
+          ::Resend::Webhooks.verify(
+            payload: request.raw_post,
+            headers: {
+              svix_id: request.headers["svix-id"],
+              svix_timestamp: request.headers["svix-timestamp"],
+              svix_signature: request.headers["svix-signature"]
+            },
+            webhook_secret: signing_secret
+          )
+        rescue RuntimeError
+          false
+        end
+
+        def signing_secret
+          Rails.application.credentials.dig(:action_mailbox, :resend_signing_secret) ||
+            ENV["RESEND_INGRESS_SIGNING_SECRET"]
+        end
+      end
+    end
+  end
+end

--- a/lib/resend.rb
+++ b/lib/resend.rb
@@ -44,6 +44,7 @@ require "resend/suppressions/batch"
 
 # Rails
 require "resend/railtie" if defined?(Rails) && defined?(ActionMailer)
+require "resend/action_mailbox" if defined?(Rails) && defined?(ActionMailbox)
 
 # Main Resend module
 module Resend

--- a/lib/resend/action_mailbox.rb
+++ b/lib/resend/action_mailbox.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require "resend"
+require "resend/action_mailbox/message_builder"
+require "resend/action_mailbox/engine" if defined?(::Rails::Engine)

--- a/lib/resend/action_mailbox/engine.rb
+++ b/lib/resend/action_mailbox/engine.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "rails/engine"
+
+module Resend
+  module ActionMailbox
+    # Rails engine that routes Resend's +email.received+ webhooks to the
+    # Action Mailbox ingress controller.
+    class Engine < ::Rails::Engine
+      initializer "resend.action_mailbox.routes" do |app|
+        app.routes.append do
+          post "/rails/action_mailbox/resend/inbound_emails",
+               to: "action_mailbox/ingresses/resend/inbound_emails#create",
+               as: :rails_resend_inbound_emails
+        end
+      end
+    end
+  end
+end

--- a/lib/resend/action_mailbox/message_builder.rb
+++ b/lib/resend/action_mailbox/message_builder.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require "mail"
+
+module Resend
+  module ActionMailbox
+    # Rebuilds the full RFC 822 source of a received email so it can be ingested
+    # by Action Mailbox.
+    #
+    # Resend's +email.received+ webhook only carries metadata, so the message is
+    # fetched from the Received Emails API. When the API exposes a raw message
+    # download it is used as-is; otherwise the message is reconstructed as a
+    # Mail::Message from its parts, downloading each attachment through the
+    # attachments API.
+    class MessageBuilder
+      # Headers that describe the reconstructed MIME structure and therefore
+      # cannot be copied verbatim from the original message.
+      STRUCTURAL_HEADERS = %w[content-type content-transfer-encoding mime-version].freeze
+
+      # Envelope fields that are set from the API response when the original
+      # header of the same name is not available.
+      ENVELOPE_FIELDS = %i[from to cc bcc reply_to subject message_id].freeze
+
+      # @param email_id [String] The ID of the received email
+      def initialize(email_id)
+        @email_id = email_id
+      end
+
+      # @return [String] the full RFC 822 source of the received email
+      def raw_email
+        raw_download || rebuild_message.to_s
+      end
+
+      private
+
+      def email
+        @email ||= Resend::Emails::Receiving.get(@email_id, html_format: "cid")
+      end
+
+      def raw_download
+        url = fetch(email[:raw], "download_url") unless blank?(email[:raw])
+        download(url) unless blank?(url)
+      end
+
+      def rebuild_message
+        Mail.new.tap do |mail|
+          copy_headers(mail)
+          copy_envelope(mail)
+          add_bodies(mail)
+          add_attachments(mail)
+        end
+      end
+
+      def copy_headers(mail)
+        (email[:headers] || {}).each do |name, value|
+          next if STRUCTURAL_HEADERS.include?(name.to_s.downcase)
+
+          Array(value).each { |val| mail.header[name.to_s] = val }
+        end
+      end
+
+      def copy_envelope(mail)
+        ENVELOPE_FIELDS.each do |field|
+          value = email[field]
+          next if blank?(value) || mail.header[field.to_s.tr("_", "-")]
+
+          mail.public_send("#{field}=", value)
+        end
+
+        mail.date ||= email[:created_at]
+
+        expose_bcc(mail)
+        copy_received_for(mail)
+      end
+
+      # Mail omits Bcc when serializing a message by default, but Action Mailbox
+      # needs it to route the email.
+      def expose_bcc(mail)
+        bcc = mail.header["bcc"]
+        bcc.include_in_headers = true if bcc.respond_to?(:include_in_headers)
+      end
+
+      # Preserve the addresses this email was received for (e.g. through a
+      # forwarding rule) so Action Mailbox can route on them.
+      def copy_received_for(mail)
+        Array(email[:received_for]).each { |address| mail.header["X-Original-To"] = address }
+      end
+
+      def add_bodies(mail)
+        html = presence(email[:html])
+        text = presence(email[:text])
+
+        if html
+          mail.text_part = build_part("text/plain", text) if text
+          mail.html_part = build_part("text/html", html)
+        elsif text
+          mail.content_type "text/plain; charset=UTF-8"
+          mail.body text
+        end
+      end
+
+      def build_part(mime_type, content)
+        Mail::Part.new(content_type: "#{mime_type}; charset=UTF-8", body: content)
+      end
+
+      def add_attachments(mail)
+        Array(email[:attachments]).each { |meta| add_attachment(mail, meta) }
+      end
+
+      def add_attachment(mail, meta)
+        details = Resend::Emails::Receiving::Attachments.get(email_id: @email_id, id: fetch(meta, "id"))
+        filename = fetch(meta, "filename") || details[:filename]
+
+        mail.attachments[filename] = {
+          mime_type: fetch(meta, "content_type") || details[:content_type],
+          content: download(details[:download_url])
+        }
+
+        decorate_attachment(mail.attachments.last, meta)
+      end
+
+      def decorate_attachment(part, meta)
+        content_id = fetch(meta, "content_id")
+        part.content_id = normalize_content_id(content_id) unless blank?(content_id)
+
+        return unless fetch(meta, "content_disposition") == "inline"
+
+        part.content_disposition = "inline; filename=\"#{part.filename}\""
+      end
+
+      def normalize_content_id(content_id)
+        content_id.start_with?("<") ? content_id : "<#{content_id}>"
+      end
+
+      def download(url)
+        response = HTTParty.get(url)
+
+        unless response.code == 200
+          raise Resend::Error::ServerError.new(
+            "Failed to download received email content (HTTP #{response.code})", response.code
+          )
+        end
+
+        response.body
+      end
+
+      # Nested objects come back from the API with string keys, but hand-built
+      # hashes (tests, console usage) often use symbols. Accept both.
+      def fetch(hash, key)
+        hash[key] || hash[key.to_sym]
+      end
+
+      def presence(value)
+        value unless blank?(value)
+      end
+
+      def blank?(value)
+        value.nil? || (value.respond_to?(:empty?) && value.empty?)
+      end
+    end
+  end
+end

--- a/resend.gemspec
+++ b/resend.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.author        = "Derich Pacheco"
   spec.email         = "carlosderich@gmail.com"
 
-  spec.files         = Dir["*.{md,txt}", "{lib}/**/*"]
+  spec.files         = Dir["*.{md,txt}", "{app,lib}/**/*"]
   spec.require_path  = "lib"
   spec.required_ruby_version = ">= 3.2"
   spec.add_dependency "base64"

--- a/spec/action_mailbox/message_builder_spec.rb
+++ b/spec/action_mailbox/message_builder_spec.rb
@@ -1,0 +1,219 @@
+# frozen_string_literal: true
+
+require "resend/action_mailbox/message_builder"
+
+RSpec.describe Resend::ActionMailbox::MessageBuilder do
+  let(:email_id) { "4ef9a417-02e9-4d39-ad75-9611e0fcc33c" }
+  let(:builder) { described_class.new(email_id) }
+
+  def http_response(code, body)
+    double(code: code, body: body)
+  end
+
+  describe "#raw_email" do
+    context "when a raw message download is available" do
+      let(:raw_source) { "From: onboarding@resend.dev\r\nSubject: Raw\r\n\r\nHello" }
+
+      before do
+        allow(Resend::Emails::Receiving).to receive(:get).and_return(
+          {
+            id: email_id,
+            raw: {
+              "download_url" => "https://example.resend.com/receiving/raw/abc?Signature=sig",
+              "expires_at" => "2026-04-03T23:13:42.674Z"
+            },
+            attachments: [{ "id" => "att_1", "filename" => "avatar.png" }]
+          }
+        )
+        allow(HTTParty).to receive(:get)
+          .with("https://example.resend.com/receiving/raw/abc?Signature=sig")
+          .and_return(http_response(200, raw_source))
+        allow(Resend::Emails::Receiving::Attachments).to receive(:get)
+      end
+
+      it "returns the raw message as-is" do
+        expect(builder.raw_email).to eq(raw_source)
+      end
+
+      it "does not call the attachments API" do
+        builder.raw_email
+        expect(Resend::Emails::Receiving::Attachments).not_to have_received(:get)
+      end
+
+      it "requests the email with cid html format" do
+        builder.raw_email
+        expect(Resend::Emails::Receiving).to have_received(:get).with(email_id, html_format: "cid")
+      end
+
+      it "raises when the raw download fails" do
+        allow(HTTParty).to receive(:get).and_return(http_response(403, "expired"))
+        expect { builder.raw_email }.to raise_error(Resend::Error::ServerError, /HTTP 403/)
+      end
+    end
+
+    context "when the message has to be reconstructed" do
+      let(:png_content) { (+"\x89PNG\r\nfakeimage").force_encoding(Encoding::BINARY) }
+      let(:pdf_content) { (+"%PDF-1.4 fakepdf").force_encoding(Encoding::BINARY) }
+
+      let(:email_payload) do
+        {
+          object: "email",
+          id: email_id,
+          to: ["delivered@resend.dev"],
+          from: "onboarding@resend.dev",
+          created_at: "2026-04-03T22:13:42.674Z",
+          subject: "Hello World",
+          html: "<p>Hi <img src=\"cid:img001\"></p>",
+          html_format: "cid",
+          text: "Hi",
+          headers: {
+            "from" => "Acme <onboarding@resend.dev>",
+            "date" => "Fri, 3 Apr 2026 22:13:42 +0000",
+            "x-custom-header" => "custom-value",
+            "mime-version" => "1.0",
+            "content-type" => "multipart/mixed; boundary=\"original\""
+          },
+          bcc: ["hidden@resend.dev"],
+          cc: ["cc@resend.dev"],
+          reply_to: ["reply@resend.dev"],
+          received_for: ["forwarded@example.com"],
+          message_id: "<111-222-333@email.example.com>",
+          raw: nil,
+          attachments: [
+            {
+              "id" => "att_inline",
+              "filename" => "avatar.png",
+              "content_type" => "image/png",
+              "content_disposition" => "inline",
+              "content_id" => "img001",
+              "size" => 4096
+            },
+            {
+              "id" => "att_file",
+              "filename" => "document.pdf",
+              "content_type" => "application/pdf",
+              "content_disposition" => nil,
+              "content_id" => nil,
+              "size" => 13_264
+            }
+          ]
+        }
+      end
+
+      before do
+        allow(Resend::Emails::Receiving).to receive(:get).and_return(email_payload)
+        allow(Resend::Emails::Receiving::Attachments).to receive(:get)
+          .with(email_id: email_id, id: "att_inline")
+          .and_return({ id: "att_inline", download_url: "https://cdn.resend.com/att_inline" })
+        allow(Resend::Emails::Receiving::Attachments).to receive(:get)
+          .with(email_id: email_id, id: "att_file")
+          .and_return({ id: "att_file", download_url: "https://cdn.resend.com/att_file" })
+        allow(HTTParty).to receive(:get).with("https://cdn.resend.com/att_inline")
+                                        .and_return(http_response(200, png_content))
+        allow(HTTParty).to receive(:get).with("https://cdn.resend.com/att_file")
+                                        .and_return(http_response(200, pdf_content))
+      end
+
+      let(:mail) { Mail.read_from_string(builder.raw_email) }
+
+      it "preserves the envelope" do
+        expect(mail.subject).to eq("Hello World")
+        expect(mail.to).to eq(["delivered@resend.dev"])
+        expect(mail.cc).to eq(["cc@resend.dev"])
+        expect(mail.bcc).to eq(["hidden@resend.dev"])
+        expect(mail.reply_to).to eq(["reply@resend.dev"])
+        expect(mail.message_id).to eq("111-222-333@email.example.com")
+      end
+
+      it "prefers the original headers over the top-level fields" do
+        expect(mail[:from].to_s).to eq("Acme <onboarding@resend.dev>")
+        expect(mail.date.year).to eq(2026)
+      end
+
+      it "copies non-structural headers and skips structural ones" do
+        expect(mail["x-custom-header"].to_s).to eq("custom-value")
+        expect(mail.content_type).not_to include("original")
+      end
+
+      it "maps received_for addresses to X-Original-To" do
+        expect(mail["X-Original-To"].to_s).to eq("forwarded@example.com")
+      end
+
+      it "builds text and html parts" do
+        expect(mail).to be_multipart
+        expect(mail.text_part.decoded).to eq("Hi")
+        expect(mail.html_part.decoded).to include("cid:img001")
+      end
+
+      it "downloads and attaches the attachments" do
+        expect(mail.attachments.map(&:filename)).to contain_exactly("avatar.png", "document.pdf")
+
+        pdf = mail.attachments.detect { |a| a.filename == "document.pdf" }
+        expect(pdf.decoded).to eq(pdf_content)
+        expect(pdf.content_type).to start_with("application/pdf")
+        expect(pdf.content_disposition).to start_with("attachment")
+      end
+
+      it "marks inline attachments with their content id" do
+        png = mail.attachments.detect { |a| a.filename == "avatar.png" }
+        expect(png.decoded).to eq(png_content)
+        expect(png.content_id).to eq("<img001>")
+        expect(png).to be_inline
+      end
+
+      it "raises when an attachment download fails" do
+        allow(HTTParty).to receive(:get).with("https://cdn.resend.com/att_file")
+                                        .and_return(http_response(500, "oops"))
+        expect { builder.raw_email }.to raise_error(Resend::Error::ServerError, /HTTP 500/)
+      end
+    end
+
+    context "when the email is text-only" do
+      before do
+        allow(Resend::Emails::Receiving).to receive(:get).and_return(
+          {
+            id: email_id,
+            from: "onboarding@resend.dev",
+            to: ["delivered@resend.dev"],
+            subject: "Plain",
+            created_at: "2026-04-03T22:13:42.674Z",
+            text: "Just text",
+            html: nil,
+            headers: {},
+            attachments: []
+          }
+        )
+      end
+
+      it "builds a simple text message" do
+        mail = Mail.read_from_string(builder.raw_email)
+        expect(mail).not_to be_multipart
+        expect(mail.decoded).to eq("Just text")
+        expect(mail.date).not_to be_nil
+      end
+    end
+
+    context "when the email is html-only" do
+      before do
+        allow(Resend::Emails::Receiving).to receive(:get).and_return(
+          {
+            id: email_id,
+            from: "onboarding@resend.dev",
+            to: ["delivered@resend.dev"],
+            subject: "Rich",
+            html: "<strong>Hello</strong>",
+            text: nil,
+            headers: {},
+            attachments: []
+          }
+        )
+      end
+
+      it "builds a message with only an html part" do
+        mail = Mail.read_from_string(builder.raw_email)
+        expect(mail.html_part.decoded).to eq("<strong>Hello</strong>")
+        expect(mail.text_part).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds an Action Mailbox ingress so Rails apps can receive inbound emails through Resend, building on the Received Emails and Attachments APIs added in #229 and earlier.

## How it works

Resend delivers inbound email as `email.received` webhooks that only carry metadata, so the ingress:

1. Verifies the webhook's Svix signature via the existing `Resend::Webhooks.verify`, using the `action_mailbox.resend_signing_secret` Rails credential or the `RESEND_INGRESS_SIGNING_SECRET` env var.
2. Fetches the full message from the Received Emails API (`html_format=cid` so inline images keep their `cid:` references).
3. Rebuilds the raw RFC 822 source: when the API returns a `raw.download_url` it is used as-is for perfect fidelity; otherwise a `Mail::Message` is reconstructed from the email's parts, downloading each attachment through the Attachments API.
4. Hands the result to `ActionMailbox::InboundEmail.create_and_extract_message_id!` for routing like any other ingress.

Reconstruction details worth noting:

- Original headers (e.g. `From` with display name) are preferred over the parsed top-level fields; structural MIME headers are regenerated.
- Inline attachments keep their `Content-ID` and inline disposition.
- `Bcc` is forced into the serialized headers (the mail gem drops it by default) and `received_for` addresses are mapped to `X-Original-To`, so Action Mailbox routing works for bcc'd and forwarded mail.

## Usage

```ruby
# config/environments/production.rb
config.action_mailbox.ingress = :resend
```

Point an `email.received` webhook at `https://example.com/rails/action_mailbox/resend/inbound_emails` and store its signing secret. Full setup is documented in the new README section.

## Structure

- `lib/resend/action_mailbox/message_builder.rb` — rebuilds the raw email (plain Ruby, no Rails dependency).
- `app/controllers/action_mailbox/ingresses/resend/inbound_emails_controller.rb` — subclasses `ActionMailbox::BaseController`, matching the status-code conventions of Rails' built-in ingresses (204 success/ignored event, 401 bad signature, 404 unconfigured ingress, 422 malformed payload, 500 missing secret).
- `lib/resend/action_mailbox/engine.rb` — appends the `POST /rails/action_mailbox/resend/inbound_emails` route; loaded from `lib/resend.rb` when `ActionMailbox` is defined, mirroring the existing railtie guard.
- Gemspec now packages the `app/` directory.

## Testing

- 14 new specs for `MessageBuilder` (raw-download path, full multipart reconstruction, text-only/html-only, download failures); full suite passes with rubocop clean.
- Verified end-to-end against a real Rails 8.1 app (eager loading on): engine route, controller autoloading, signature verification, event filtering, error statuses, and `InboundEmail` creation with correct parts, attachments, and recipients.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Action Mailbox ingress so Rails apps can receive inbound emails through Resend. The ingress verifies webhook signatures, fetches the full message from the Resend API, and rebuilds the raw email before handing it to Action Mailbox.

**New Features**
- Uses the raw message download when available; otherwise reconstructs a `Mail::Message` from the API's parts and attachments.
- Keeps inline attachments' `Content-ID` and disposition intact.
- Preserves `Bcc` and maps `received_for` addresses to `X-Original-To` for correct routing.

**Migration**
- Set `config.action_mailbox.ingress = :resend` and configure `Resend.api_key`.
- Point an `email.received` webhook at `/rails/action_mailbox/resend/inbound_emails` and store its signing secret in `action_mailbox.resend_signing_secret` or the `RESEND_INGRESS_SIGNING_SECRET` env var.

<sup>Written for commit e152b6fd3ab02196cd994fbd074c1a2721479524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

