### PR TITLE
feat(contacts): add support for listing contacts by segment

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,6 +266,7 @@ GEM
 PLATFORMS
   aarch64-linux
   arm64-darwin-22
+  arm64-darwin-23
   arm64-darwin-25
   x86_64-darwin-20
   x86_64-darwin-21

--- a/examples/contacts.rb
+++ b/examples/contacts.rb
@@ -8,10 +8,7 @@ Resend.api_key = ENV["RESEND_API_KEY"]
 
 def example
 
-  audience_id = "ca4e37c5-a82a-4199-a3b8-bf912a6472aa"
-
   params = {
-    audience_id: audience_id,
     email: "steve@example.com",
     first_name: "Steve",
     last_name: "Woz",
@@ -22,29 +19,28 @@ def example
   puts "Contact created: #{contact}"
 
   update_params = {
-    audience_id: audience_id,
     email: params[:email],
     # id: contact[:id],
     unsubscribed: false,
     first_name: "Updated",
   }
 
-  retrieved = Resend::Contacts.get(id: contact[:id], audience_id: audience_id)
+  retrieved = Resend::Contacts.get(id: contact[:id])
   puts "Retrived contact by ID"
   puts retrieved
 
-  retrieved_by_email = Resend::Contacts.get(email: params[:email], audience_id: audience_id)
+  retrieved_by_email = Resend::Contacts.get(email: params[:email])
   puts "Retrived contact by Email"
   puts retrieved_by_email
 
   updated = Resend::Contacts.update(update_params)
   puts "Updated contact: #{updated}"
 
-  contacts = Resend::Contacts.list(audience_id: audience_id)
+  contacts = Resend::Contacts.list
   puts contacts
 
   # Example with pagination
-  paginated_contacts = Resend::Contacts.list(audience_id: audience_id, limit: 10)
+  paginated_contacts = Resend::Contacts.list(limit: 10)
   puts "Paginated contacts (limit 10):"
   puts paginated_contacts
 
@@ -99,10 +95,10 @@ def example
   puts "Topic deleted"
 
   # delete by id
-  del = Resend::Contacts.remove(id: contact[:id], audience_id: audience_id)
+  del = Resend::Contacts.remove(id: contact[:id])
 
   # delete by email
-  # del = Resend::Contacts.remove(email: "steve@example.com", audience_id: audience_id)
+  # del = Resend::Contacts.remove(email: "steve@example.com")
 
   puts "Deleted #{del}"
 end

--- a/examples/contacts_segments.rb
+++ b/examples/contacts_segments.rb
@@ -55,7 +55,12 @@ def example
   )
   puts "Segments with pagination: #{segments_paginated}"
 
-  # Step 7: Remove contact from the segment
+  # Step 7: You can also list the contacts that are in a segment
+  puts "\nListing contacts in the segment (should include the contact)..."
+  contacts = Resend::Contacts.list(segment_id: segment_id)
+  puts "Contacts in the email: #{contacts}"
+
+  # Step 8: Remove contact from the segment
   puts "\nRemoving contact from segment..."
   removed = Resend::Contacts::Segments.remove(
     contact_id: contact_id,
@@ -63,7 +68,7 @@ def example
   )
   puts "Removed contact from segment: #{removed}"
 
-  # Step 8: Cleanup - remove contact and segment
+  # Step 9: Cleanup - remove contact and segment
   puts "\nCleaning up..."
   Resend::Contacts.remove(id: contact_id)
   puts "Deleted contact: #{contact_id}"

--- a/examples/contacts_segments.rb
+++ b/examples/contacts_segments.rb
@@ -58,7 +58,7 @@ def example
   # Step 7: You can also list the contacts that are in a segment
   puts "\nListing contacts in the segment (should include the contact)..."
   contacts = Resend::Contacts.list(segment_id: segment_id)
-  puts "Contacts in the email: #{contacts}"
+  puts "Contacts in the segment: #{contacts}"
 
   # Step 8: Remove contact from the segment
   puts "\nRemoving contact from segment..."

--- a/examples/with_pagination.rb
+++ b/examples/with_pagination.rb
@@ -57,7 +57,7 @@ if audiences[:data] && !audiences[:data].empty?
   if audience_id && !audience_id.empty?
     puts "List first 5 contacts from audience '#{audience_id}':"
     begin
-      contacts = Resend::Contacts.list(audience_id, { limit: 5 })
+      contacts = Resend::Contacts.list(audience_id: audience_id, limit: 5 )
       puts contacts
       puts "Has more: #{contacts[:has_more]}" if contacts.key?(:has_more)
     rescue Resend::Error => e
@@ -80,4 +80,4 @@ puts
 puts "Example usage:"
 puts "Resend::ApiKeys.list({ limit: 25, after: 'key_123' })"
 puts "Resend::Domains.list({ limit: 10, before: 'domain_456' })"
-puts "Resend::Contacts.list('audience_id', { limit: 50 })"
+puts "Resend::Contacts.list(audience_id: 'audience_id', limit: 50 )"

--- a/lib/resend/contacts.rb
+++ b/lib/resend/contacts.rb
@@ -66,6 +66,9 @@ module Resend
         audience_id = params[:audience_id]
         path = if audience_id
                  Resend::PaginationHelper.build_paginated_path("audiences/#{audience_id}/contacts", params)
+               elsif params[:segment_id]
+                 segment_id = params.delete(:segment_id)
+                 Resend::PaginationHelper.build_paginated_path("segments/#{segment_id}/contacts", params)
                else
                  Resend::PaginationHelper.build_paginated_path("contacts", params)
                end

--- a/lib/resend/contacts.rb
+++ b/lib/resend/contacts.rb
@@ -58,17 +58,22 @@ module Resend
       # @example List contacts with pagination
       #   Resend::Contacts.list(limit: 10)
       #
+      # @example List contacts scoped to a segment
+      #   Resend::Contacts.list(segment_id: "seg_456", limit: 10)
+      #
       # @example List contacts scoped to an audience
       #   Resend::Contacts.list(audience_id: "aud_456", limit: 10)
       #
       # https://resend.com/docs/api-reference/contacts/list-contacts
       def list(params = {})
-        audience_id = params[:audience_id]
-        path = if audience_id
-                 Resend::PaginationHelper.build_paginated_path("audiences/#{audience_id}/contacts", params)
+        path = if params[:audience_id]
+                 audience_id = params[:audience_id]
+                 Resend::PaginationHelper.build_paginated_path("audiences/#{audience_id}/contacts",
+                                                               params.except(:audience_id))
                elsif params[:segment_id]
-                 segment_id = params.delete(:segment_id)
-                 Resend::PaginationHelper.build_paginated_path("segments/#{segment_id}/contacts", params)
+                 segment_id = params[:segment_id]
+                 Resend::PaginationHelper.build_paginated_path("segments/#{segment_id}/contacts",
+                                                               params.except(:segment_id))
                else
                  Resend::PaginationHelper.build_paginated_path("contacts", params)
                end

--- a/spec/contacts_spec.rb
+++ b/spec/contacts_spec.rb
@@ -89,9 +89,8 @@ RSpec.describe "Contacts" do
 
   describe "list contacts" do
 
-    it "should list contacts (new style with hash)" do
-
-      resp = {
+    let(:resp) {
+      {
         "object": "list",
         "data": [
           {
@@ -104,9 +103,13 @@ RSpec.describe "Contacts" do
           }
         ]
       }
+    }
 
+    it "should list contacts (new style with hash)" do
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+
       contacts = Resend::Contacts.list(audience_id: audience_id)
+
       expect(contacts[:object]).to eql "list"
       expect(contacts[:data].length).to eql 1
       expect(contacts[:data][0]["id"]).to eql "e169aa45-1ecf-4183-9955-b1499d5701d3"
@@ -117,23 +120,28 @@ RSpec.describe "Contacts" do
     end
 
     it "should list contacts with pagination" do
-
-      resp = {
-        "object": "list",
-        "data": [
-          {
-            "id" => "e169aa45-1ecf-4183-9955-b1499d5701d3",
-            "email" => "steve.wozniak@gmail.com",
-            "first_name" => "Steve",
-            "last_name" => "Wozniak",
-            "created_at" => "2023-10-06 23:47:56.678+00",
-            "unsubscribed" => false
-          }
-        ]
-      }
-
       allow_any_instance_of(Resend::Request).to receive(:perform).and_return(resp)
+
       contacts = Resend::Contacts.list(audience_id: audience_id, limit: 10)
+
+      expect(contacts[:object]).to eql "list"
+      expect(contacts[:data].length).to eql 1
+      expect(contacts[:data][0]["id"]).to eql "e169aa45-1ecf-4183-9955-b1499d5701d3"
+      expect(contacts[:data][0]["first_name"]).to eql "Steve"
+      expect(contacts[:data][0]["last_name"]).to eql "Wozniak"
+      expect(contacts[:data][0]["email"]).to eql "steve.wozniak@gmail.com"
+      expect(contacts[:data][0]["unsubscribed"]).to be false
+    end
+
+    it "should list contacts by segment" do
+      segment_id = "78261eea-8f8b-4381-83c6-79fa7120f1cf"
+      mock_response = Resend::Response.new(resp, {})
+      mock_request = double("Resend::Request")
+      allow(mock_request).to receive(:perform).and_return(mock_response)
+      expect(Resend::Request).to receive(:new).with("segments/#{segment_id}/contacts", {}, "get").and_return(mock_request)
+
+      contacts = Resend::Contacts.list(segment_id: segment_id)
+      
       expect(contacts[:object]).to eql "list"
       expect(contacts[:data].length).to eql 1
       expect(contacts[:data][0]["id"]).to eql "e169aa45-1ecf-4183-9955-b1499d5701d3"

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -165,8 +165,7 @@ RSpec.describe "Pagination" do
       request_instance = instance_double(Resend::Request)
       allow(request_instance).to receive(:perform).and_return(resp)
       allow(Resend::Request).to receive(:new) do |path, body, verb|
-        expect(path).to include("audiences/audience_123/contacts")
-        expect(path).to include("limit=20")
+        expect(path).to eql("audiences/audience_123/contacts?limit=20")
         request_instance
       end
 


### PR DESCRIPTION
https://resend.com/docs/api-reference/segments/list-segment-contacts

Also replaces or removes audiences from some examples.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for listing contacts by segment and updates examples to match the current API where contacts don't require an `audience_id`.

- `Resend::Contacts.list` now accepts `segment_id` and hits `/segments/{segment_id}/contacts`.
- `audience_id` and `segment_id` are excluded from query parameters when building paginated paths.
- Examples and specs updated to cover segment listing and the new path format.

<sup>Written for commit daf1bf606516ee533e5ab9dbe749dd6a4a79f975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/resend/resend-ruby/pull/235?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

