### PR TITLE
feat(webhooks): add event replay endpoint

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,9 @@ Layout/LineLength:
 Metrics/ClassLength:
   Max: 169
 
+Metrics/ModuleLength:
+  Max: 169
+
 Metrics/MethodLength:
   Max: 14
 

--- a/examples/webhooks.rb
+++ b/examples/webhooks.rb
@@ -71,6 +71,10 @@ if webhook_events[:data].any?
   puts "\nWebhook event: #{webhook_event[:id]}"
   puts "Status: #{webhook_event[:status]}"
 
+  # Replay a webhook event
+  replayed_event = Resend::Webhooks.replay_event(webhook[:id], event_id)
+  puts "\nReplayed webhook event: #{replayed_event[:id]}"
+
   # List delivery attempts for a webhook event
   attempts = Resend::Webhooks.list_event_attempts(webhook[:id], event_id, limit: 10)
   puts "\nDelivery attempts: #{attempts[:data].length}"

--- a/lib/resend/webhooks.rb
+++ b/lib/resend/webhooks.rb
@@ -117,6 +117,22 @@ module Resend
         Resend::Request.new(path, {}, "get").perform
       end
 
+      # Replay a webhook event
+      #
+      # Queues one more delivery of the event to the webhook. Manual replays do not schedule automatic retries.
+      #
+      # @param webhook_id [String] The webhook ID
+      # @param event_id [String] The webhook event ID
+      #
+      # @return [Hash] The replayed webhook event id and object type
+      #
+      # @example
+      #   Resend::Webhooks.replay_event("4dd369bc-aa82-4ff3-97de-514ae3000ee0", "msg_123")
+      def replay_event(webhook_id, event_id)
+        path = "webhooks/#{webhook_id}/events/#{event_id}/replay"
+        Resend::Request.new(path, {}, "post").perform
+      end
+
       # Retrieve delivery attempts for a webhook event
       #
       # @param webhook_id [String] The webhook ID

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -108,17 +108,13 @@ RSpec.describe "Webhooks" do
 
   describe "replay_event" do
     it "replays a webhook event" do
-      resp = { "object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2" }
       request = instance_double(Resend::Request)
       expect(Resend::Request).to receive(:new)
         .with("webhooks/webhook_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay", {}, "post")
         .and_return(request)
-      expect(request).to receive(:perform).and_return(resp)
+      expect(request).to receive(:perform)
 
-      result = Resend::Webhooks.replay_event("webhook_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2")
-
-      expect(result[:object]).to eql("webhook_event")
-      expect(result[:id]).to eql("msg_1srOrx2ZWZBpBUvZwXKQmoEYga2")
+      Resend::Webhooks.replay_event("webhook_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2")
     end
   end
 

--- a/spec/webhooks_spec.rb
+++ b/spec/webhooks_spec.rb
@@ -106,6 +106,22 @@ RSpec.describe "Webhooks" do
     end
   end
 
+  describe "replay_event" do
+    it "replays a webhook event" do
+      resp = { "object": "webhook_event", "id": "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2" }
+      request = instance_double(Resend::Request)
+      expect(Resend::Request).to receive(:new)
+        .with("webhooks/webhook_123/events/msg_1srOrx2ZWZBpBUvZwXKQmoEYga2/replay", {}, "post")
+        .and_return(request)
+      expect(request).to receive(:perform).and_return(resp)
+
+      result = Resend::Webhooks.replay_event("webhook_123", "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2")
+
+      expect(result[:object]).to eql("webhook_event")
+      expect(result[:id]).to eql("msg_1srOrx2ZWZBpBUvZwXKQmoEYga2")
+    end
+  end
+
   describe "list_event_attempts" do
     it "lists webhook event attempts with pagination" do
       request = instance_double(Resend::Request)


### PR DESCRIPTION
Adds `Resend::Webhooks.replay_event(webhook_id, event_id)`, which calls `POST /webhooks/{webhook_id}/events/{event_id}/replay` and returns `{ object: "webhook_event", id: "msg_..." }`. Queues one more delivery of the event to the webhook; manual replays do not schedule automatic retries.

```ruby
replayed = Resend::Webhooks.replay_event(
  "4dd369bc-aa82-4ff3-97de-514ae3000ee0",
  "msg_1srOrx2ZWZBpBUvZwXKQmoEYga2"
)
puts replayed[:id]
```

Also adds the call to `examples/webhooks.rb` and sets `Metrics/ModuleLength: 169` in `.rubocop.yml`. The `Webhooks` module is a flat list of one-method-per-endpoint wrappers, so its length tracks the API surface; the default 100 was crossed by this method and would be crossed again by the next one.

Spec PR: https://github.com/resend/resend-openapi/pull/112
API PR: https://github.com/resend/resend-monorepo/pull/9535

Checks (Ruby 4.0.6, `bundle install`): `bundle exec rubocop` no offenses, `bundle exec rake spec` 400 examples, 0 failures. No live API call was made; version bump left for the chore PR.

Part of DEV-2005.

Linear: https://linear.app/resend/issue/DEV-2011